### PR TITLE
default HOSTARCH to UNIX in lua code, lets this build on OpenBSD

### DIFF
--- a/src/game/g_lua.h
+++ b/src/game/g_lua.h
@@ -44,12 +44,8 @@
 #define FIELD_FLAG_READONLY 8 // read-only access
 
 // define HOSTARCH and EXTENSION depending on host architecture
-#if defined __linux__
 
-#define HOSTARCH    "UNIX"
-#define EXTENSION   "so"
-
-#elif defined WIN32
+#if defined WIN32
 
 #define HOSTARCH    "WIN32"
 #define EXTENSION   "dll"
@@ -57,6 +53,11 @@
 #elif defined __APPLE__
 
 #define HOSTARCH    "MACOS"
+#define EXTENSION   "so"
+
+#else
+
+#define HOSTARCH    "UNIX"
 #define EXTENSION   "so"
 
 #endif


### PR DESCRIPTION
This defaults the HOSTARCH to UNIX so the code will compile on *BSD/Solaris/etc
