### PR TITLE
ui: reverse clean buttons order

### DIFF
--- a/etmain/ui/options_clean.menu
+++ b/etmain/ui/options_clean.menu
@@ -54,7 +54,7 @@ menuDef {
 	LABEL( SUBWINDOW_X+2, SUBWINDOW_Y+106, (SUBWINDOW_WIDTH)-4, 10, "Consult our wiki for documentation.", .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 	LABEL( SUBWINDOW_X+2, SUBWINDOW_Y+122, (SUBWINDOW_WIDTH)-4, 10, "Press 'ABORT' if you don't know what you are doing here.", .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "SIMPLE ClEAN", .3, 14, exec "exec clean_simple.cfg" ; close options_clean ; open options )
-	BUTTON( SUBWINDOW_X+6+.33*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "FULL CLEAN", .3, 14, exec "exec clean_full.cfg" ; close options_clean ; open options )
-	BUTTON( SUBWINDOW_X+6+.33*(SUBWINDOW_WIDTH-18)+6+.33*(SUBWINDOW_WIDTH-24)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "ABORT", .3, 14, close options_clean ; open options )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "ABORT", .3, 14, close options_clean ; open options )
+	BUTTON( SUBWINDOW_X+6+.33*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "SIMPLE CLEAN", .3, 14, exec "exec clean_simple.cfg" ; close options_clean ; open options )
+	BUTTON( SUBWINDOW_X+6+.33*(SUBWINDOW_WIDTH-18)+6+.33*(SUBWINDOW_WIDTH-24)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .33*(SUBWINDOW_WIDTH-18), 18, "FULL CLEAN", .3, 14, exec "exec clean_full.cfg" ; close options_clean ; open options )
 }


### PR DESCRIPTION
This fix a UX issue. As the 'back' button is usually on the left side, this avoid to accidentally press the "full clean" button instead of the "abort" button.
