### PR TITLE
ui: reverted to better credits pages usuability

### DIFF
--- a/etmain/ui/credits_activision.menu
+++ b/etmain/ui/credits_activision.menu
@@ -122,5 +122,11 @@ menuDef {
 	LABELWHITE( 6+.5*(WINDOW_WIDTH-24)+12, CREDITS_Y+300, .5*(WINDOW_WIDTH-24), 10, "Manager, Customer Support", .2, ITEM_ALIGN_LEFT, 0, 8 )
 
 // Buttons //
-	BUTTON( 260, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_activision ; open credits_etlegacy )
+#ifdef FUI
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_activision ; open main )
+#else
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_activision ; open ingame_main )
+#endif
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "ID SOFTWARE", .3, 14, close credits_activision ; open credits_idsoftware )
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "ADDITIONAL", .3, 14, close credits_activision ; open credits_additional )
 }

--- a/etmain/ui/credits_additional.menu
+++ b/etmain/ui/credits_additional.menu
@@ -229,5 +229,11 @@ menuDef {
 	LABELWHITE( 6, CREDITS_Y+244, WINDOW_WIDTH-12, 10, "Original Soundtrack by Bill Brown.", .2, ITEM_ALIGN_CENTER, (.5*(WINDOW_WIDTH-12)), 8 )
 	
 // Buttons //
-	BUTTON( 260, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_additional ; open credits_etlegacy )
+#ifdef FUI
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_additional ; open main )
+#else
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_additional ; open ingame_main )
+#endif
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "ACTIVISION", .3, 14, close credits_additional ; open credits_activision )
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "ET 2.60", .3, 14, close credits_additional ; open credits_et260 )
 }

--- a/etmain/ui/credits_et260.menu
+++ b/etmain/ui/credits_et260.menu
@@ -129,5 +129,10 @@ menuDef {
 	LABELWHITE( 6, CREDITS_Y+300, (WINDOW_WIDTH-24)+12, 10, "Mac OS X is a trademark of Apple Computer, Inc., registered in the U.S. and other countries.", .2, ITEM_ALIGN_CENTER, .5*((WINDOW_WIDTH-24)+12), 8 )
 
 // Buttons //
-	BUTTON( 260, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_et260 ; open credits_etlegacy )
+#ifdef FUI
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_et260 ; open main )
+#else
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_et260 ; open ingame_main )
+#endif
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "ADDITIONAL", .3, 14, close credits_et260 ; open credits_additional )
 }

--- a/etmain/ui/credits_etlegacy.menu
+++ b/etmain/ui/credits_etlegacy.menu
@@ -169,13 +169,9 @@ menuDef {
 
 // Buttons //
 #ifdef FUI
-	BUTTON( 25, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_etlegacy ; open main )
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_etlegacy ; open main )
 #else
-	BUTTON( 25, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_etlegacy ; open ingame_main )
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_etlegacy ; open ingame_main )
 #endif
-	BUTTON( 25+.33*(WINDOW_WIDTH-350)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-350), 18, "SPLASH DAMAGE", .2, 14, close credits_etlegacy ; open credits_splashdamage )
-	BUTTON( 25+.33*(WINDOW_WIDTH-350)+6+.34*(WINDOW_WIDTH-350)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-350), 18, "ID SOFTWARE", .2, 14, close credits_etlegacy ; open credits_idsoftware )
-	BUTTON( 25+.33*(WINDOW_WIDTH-350)+6+.703*(WINDOW_WIDTH-350)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-350), 18, "ACTIVISION", .2, 14, close credits_etlegacy ; open credits_activision )
-	BUTTON( 25+.33*(WINDOW_WIDTH-350)+6+1.064*(WINDOW_WIDTH-350)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-350), 18, "ADDITIONAL", .2, 14, close credits_etlegacy ; open credits_additional )
-	BUTTON( 25+.33*(WINDOW_WIDTH-350)+6+1.426*(WINDOW_WIDTH-350)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-350), 18, "ET 2.60", .2, 14, close credits_etlegacy ; open credits_et260 )
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "SPLASH DAMAGE", .3, 14, close credits_etlegacy ; open credits_splashdamage )
 }

--- a/etmain/ui/credits_idsoftware.menu
+++ b/etmain/ui/credits_idsoftware.menu
@@ -88,5 +88,11 @@ menuDef {
 	LABELWHITE( 6, CREDITS_Y+48, WINDOW_WIDTH-12, 10, "Production, development and technical assistance provided by id Software.", .2, ITEM_ALIGN_CENTER, (.5*(WINDOW_WIDTH-12)), 8 )
 
 // Buttons //
-	BUTTON( 260, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_idsoftware ; open credits_etlegacy )
+#ifdef FUI
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_idsoftware ; open main )
+#else
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_idsoftware ; open ingame_main )
+#endif
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "SPLASH DAMAGE", .3, 14, close credits_idsoftware ; open credits_splashdamage )
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "ACTIVISION", .3, 14, close credits_idsoftware ; open credits_activision )
 }

--- a/etmain/ui/credits_splashdamage.menu
+++ b/etmain/ui/credits_splashdamage.menu
@@ -186,5 +186,11 @@ menuDef {
 	LABELWHITE( 6+.5*(WINDOW_WIDTH-24)+12, CREDITS_Y+280, .5*(WINDOW_WIDTH-24), 10, "Additional Level Design", .2, ITEM_ALIGN_LEFT, 0, 8 )
 
 // Buttons //
-	BUTTON( 260, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-350), 18, "BACK", .2, 14, close credits_splashdamage ; open credits_etlegacy )
+#ifdef FUI
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_splashdamage ; open main )
+#else
+        BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "BACK", .3, 14, close credits_splashdamage ; open ingame_main )
+#endif
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "ET LEGACY", .3, 14, close credits_splashdamage ; open credits_etlegacy )
+        BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "ID SOFTWARE", .3, 14, close credits_splashdamage ; open credits_idsoftware )
 }


### PR DESCRIPTION
This reverts to the old 'fashion' credits pages usuability. Navigation
between the pages are done with virtual "next" and "previous" style
buttons. A single click on the 'BACK' button returns to the main menu
(or ingame menu), instead of the current two clicks needed. Lastly, the
menu bar is less crowded with only 3 buttons instead of 6.
