### PR TITLE
cgame: fixed cg_drawTimeSeconds and added leading zero, refs #283

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1687,11 +1687,11 @@ static float CG_DrawLocalTime(float y)
 	{
 		if (cg_drawTimeSeconds.integer)
 		{
-			s = va("%i:%i", time.tm_hour, time.tm_min);
+			s = va("%02i:%02i:%02i", time.tm_hour, time.tm_min, time.tm_sec);
 		}
 		else
 		{
-			s = va("%i:%i.%i", time.tm_hour, time.tm_min, time.tm_sec);
+			s = va("%02i:%02i", time.tm_hour, time.tm_min);
 		}
 	}
 	else
@@ -1703,11 +1703,11 @@ static float CG_DrawLocalTime(float y)
 
 		if (cg_drawTimeSeconds.integer)
 		{
-			s = va("%i:%i %s", (pmtime ? time.tm_hour - 12 : time.tm_hour), time.tm_min, (pmtime ? "PM" : "AM"));
+			s = va("%i:%02i:%02i %s", (pmtime ? time.tm_hour - 12 : time.tm_hour), time.tm_min, time.tm_sec, (pmtime ? "PM" : "AM"));
 		}
 		else
 		{
-			s = va("%i:%i.%i %s", (pmtime ? time.tm_hour - 12 : time.tm_hour), time.tm_min, time.tm_sec, (pmtime ? "PM" : "AM"));
+			s = va("%i:%02i %s", (pmtime ? time.tm_hour - 12 : time.tm_hour), time.tm_min, (pmtime ? "PM" : "AM"));
 		}
 	}
 


### PR DESCRIPTION
cg_drawTimeSeconds 1 displays seconds, 0 is disabled. Also use ':' instead
of '.' for second delimiter, and always use double digit for sec, min. Use
double digit for hours unless the 12 hours format is selected.
