### PR TITLE
cgame: always use ETPro style with cg_drawWeaponFlashIcon

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -830,7 +830,7 @@ static void CG_DrawGunIcon(rectDef_t location)
 	{
 		CG_DrawPlayerWeaponIcon(&rect, qtrue, ITEM_ALIGN_RIGHT, &colorWhite);
 	}
-	else if (cg_drawWeaponIconFlash.integer == 2)  // ETPro style
+	else // ETPro style
 	{
 		int ws =
 #if FEATURE_MULTIVIEW
@@ -839,15 +839,6 @@ static void CG_DrawGunIcon(rectDef_t location)
 		    BG_simpleWeaponState(cg.snap->ps.weaponstate);
 
 		CG_DrawPlayerWeaponIcon(&rect, (ws != WSTATE_IDLE), ITEM_ALIGN_RIGHT, ((ws == WSTATE_SWITCH || ws == WSTATE_RELOAD) ? &colorYellow : (ws == WSTATE_FIRE) ? &colorRed : &colorWhite));
-	}
-	else
-	{
-		int ws =
-#if FEATURE_MULTIVIEW
-		    (cg.mvTotalClients > 0) ? cgs.clientinfo[cg.snap->ps.clientNum].weaponState :
-#endif
-		    BG_simpleWeaponState(cg.snap->ps.weaponstate);
-		CG_DrawPlayerWeaponIcon(&rect, (ws != WSTATE_IDLE), ITEM_ALIGN_RIGHT, ((ws == WSTATE_SWITCH) ? &colorWhite : (ws == WSTATE_FIRE) ? &colorRed : &colorYellow));
 	}
 }
 


### PR DESCRIPTION
cg_drawWeaponFlashIcon = 1 is the original etmain style, which is
a dumbed down option of the ETPro style (2). This completely replaces
the etmain style by the ETPro style (0: disabled, 1: ETPro style)
