### PR TITLE
renderer: fixed bsp flares causing surface corruption

### DIFF
--- a/src/renderer/tr_world.c
+++ b/src/renderer/tr_world.c
@@ -159,10 +159,6 @@ static int R_DlightSurface(msurface_t *surface, int dlightBits)
 	float        radius;
 	srfGeneric_t *gen;
 
-
-	// get generic surface
-	gen = (srfGeneric_t *) surface->data;
-
 	// made surface dlighting generic, inline with q3map2 surface classification
 	switch ((surfaceType_t) *surface->data)
 	{
@@ -173,9 +169,11 @@ static int R_DlightSurface(msurface_t *surface, int dlightBits)
 		break;
 
 	default:
-		gen->dlightBits = 0;
 		return 0;
 	}
+
+	// get generic surface
+	gen = (srfGeneric_t *) surface->data;
 
 	// debug code
 	// gen->dlightBits = dlightBits;


### PR DESCRIPTION
In R_DlightSurface, gen isn't pointing to a srfGeneric_t if not SF_FACE, SF_TRIANGLES, SF_GRID, or SF_FOLIAGE. Writing to it causes unknown memory to be overwritten.

Default ET maps do not have BSP flares (SF_FLARE), which use the affected code.

---

note: discovered in my [project](https://github.com/zturtleman/spearmint) because q3 maps have BSP flares.
