### PR TITLE
misc: visual studio warnings fix

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -63,6 +63,7 @@
 
 #ifdef USE_WINDOWS_CONSOLE
 #include <windows.h>
+#include <sys_win32.h>
 #endif
 
 static char binaryPath[MAX_OSPATH] = { 0 };


### PR DESCRIPTION
etlegacy\src\sys\sys_main.c(478) : warning C4013: 'Sys_SetErrorText' undefined; assuming extern returning int
etlegacy\src\sys\sys_main.c(479) : warning C4013: 'Sys_ShowConsole' undefined; assuming extern returning int
