### PR TITLE
Fixing incorrect memset size in game/trap_Trace

### DIFF
--- a/src/game/g_syscalls.c
+++ b/src/game/g_syscalls.c
@@ -207,7 +207,7 @@ void trap_Trace(trace_t *results, const vec3_t start, const vec3_t mins, const v
 		float newMaxZ = ClientHitboxMaxZ(hitEnt);
 
 		hitEnt->r.maxs[2] = newMaxZ;
-		memset(results, 0, sizeof(results));
+		memset(results, 0, sizeof(trace_t));
 		syscall(G_TRACE, results, start, mins, maxs, end, passEntityNum, contentmask);
 		hitEnt->r.maxs[2] = oldMaxZ;
 	}


### PR DESCRIPTION
The memset is attempting to zero the entire incoming trace_t, but ends up only zeroing the first 4 or 8 bytes of it (depending on the arch).
