### PR TITLE
Fixes issue #412

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -631,7 +631,8 @@ extern vec4_t clrBrownLineFull;
 #define FRAMETIME           100                 // msec
 
 #define Q_COLOR_ESCAPE  '^'
-#define Q_IsColorString(p)  (p && *(p) == Q_COLOR_ESCAPE && *((p) + 1) && *((p) + 1) != Q_COLOR_ESCAPE)
+#define Q_IsValidColorChar(c) ((c == '*') || ((toupper(c) - '0') >= 0 && (toupper(c) - '0') < 32))
+#define Q_IsColorString(p)    ((p) && *(p) == Q_COLOR_ESCAPE && *((p) + 1) && Q_IsValidColorChar(*((p) + 1)))
 
 #define COLOR_BLACK     '0'
 #define COLOR_RED       '1'


### PR DESCRIPTION
The first problem described is (when connected to a server) typing into the console: "^<Return>more<Return>" where <Return> means pressing the return key, the scrollback would show:

]Bob: ]more
Bob: more

Instead of:

]^
Bob: ^
]more
Bob: more

This was caused by Q_IsColorString() being inaccurate and identifying "^\n" as a color string, resulting in the \n never ending up in the buffer.

The change to Q_IsColorString() fixes this by explicitly whitelisting the valid range of chars that map to g_color_table and the COLOR_NULL char.
    So definitively:
        *0123456789:;<=>?ABCDEFGHIJKLMNO

```
Along with lowercase a-o for convenience.
```
