### PR TITLE
client: eliminated need for duplicate lib copies

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -796,6 +796,24 @@ void *Sys_LoadGameDll(const char *name,
 		libHandle = Sys_TryLibraryLoad(basepath, gamedir, fname);
 	}
 
+#ifndef DEDICATED
+	// According to the code above, if the server is not pure, then the
+	// lib must either already be in the homepath, or in the basepath,
+	// without being in a pak. For a pure server, it always grabs the lib
+	// from within a pak. This means there must be two copies of the lib!
+	//
+	// So now, if connecting to an impure server, and the lib was not
+	// loaded from homepath or the basepath, let's pull it out of the pak.
+	// This means we only *need* the copy that's in the pak, and will use
+	// it if another copy isn't found first.
+	if (!libHandle && !Cvar_VariableValue("sv_pure") && Q_stricmp(name, "qagame"))
+	{
+		Com_Printf("Sys_LoadGameDll -> FS_CL_ExtractFromPakFile(%s, %s, %s)\n", homepath, gamedir, fname);
+		FS_CL_ExtractFromPakFile(homepath, gamedir, fname);
+		libHandle = Sys_TryLibraryLoad(homepath, gamedir, fname);
+	}
+#endif
+
 	// HACK: sometimes a library is loaded from the mod dir when it shouldn't. Why?
 	if (!libHandle && strcmp(gamedir, DEFAULT_MODGAME))
 	{


### PR DESCRIPTION
The libs can now live happily only in a basepath pk3. See code comment.

There was some discussion in IRC about this earlier today, stemming from:
https://gist.github.com/swillits/631ae0132b5fea1347b5/raw/209206be80249f14bbd3718afef48ac914db9d52/gistfile1.txt

I took a closer look at it and don't see any downsides to this.
