### PR TITLE
renderer: skip unhandled marksurfaces when calculating leaf bounds

### DIFF
--- a/src/renderer/tr_bsp.c
+++ b/src/renderer/tr_bsp.c
@@ -2044,6 +2044,7 @@ static void R_SetParent(mnode_t *node, mnode_t *parent)
 				    gen->surfaceType != SF_TRIANGLES &&
 				    gen->surfaceType != SF_FOLIAGE)
 				{
+					mark++;
 					continue;
 				}
 				AddPointToBounds(gen->bounds[0], node->surfMins, node->surfMaxs);

--- a/src/renderer2/tr_bsp.c
+++ b/src/renderer2/tr_bsp.c
@@ -5046,6 +5046,7 @@ static void R_SetParent(bspNode_t *node, bspNode_t *parent)
 				if (gen->surfaceType != SF_FACE &&
 				    gen->surfaceType != SF_GRID && gen->surfaceType != SF_TRIANGLES) // && gen->surfaceType != SF_FOLIAGE)
 				{
+					mark++;
 					continue;
 				}
 				AddPointToBounds(gen->bounds[0], node->surfMins, node->surfMaxs);

--- a/src/rendererGLES/tr_bsp.c
+++ b/src/rendererGLES/tr_bsp.c
@@ -2041,6 +2041,7 @@ static void R_SetParent(mnode_t *node, mnode_t *parent)
 				    gen->surfaceType != SF_TRIANGLES &&
 				    gen->surfaceType != SF_FOLIAGE)
 				{
+					mark++;
 					continue;
 				}
 				AddPointToBounds(gen->bounds[0], node->surfMins, node->surfMaxs);


### PR DESCRIPTION
BSP flares in leafs cause surfaces after it not to be added to bounds (surfMins and surfMaxs) used by dlight culling code.

continue is run, but mark++ is not. This causes the flare to be checked again instead of the the next surface.

---

ET maps do not have BSP flares, so I assume this wasn't causing problems. I found it using ET dlight culling code with Q3 maps. https://github.com/zturtleman/spearmint/commit/7c0a62a8e4004df241dc5171b70644572cbfa5cb
