### PR TITLE
renderers: fix MDS/MDM LOD using frontend data in backend code

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -812,10 +812,8 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 		re.RenderScene(VMA(1));
 		return 0;
 	case CG_R_SAVEVIEWPARMS:
-		re.SaveViewParms();
 		return 0;
 	case CG_R_RESTOREVIEWPARMS:
-		re.RestoreViewParms();
 		return 0;
 	case CG_R_SETCOLOR:
 		re.SetColor(VMA(1));

--- a/src/renderer/tr_animation_mdm.c
+++ b/src/renderer/tr_animation_mdm.c
@@ -88,7 +88,7 @@ static int totalrv, totalrt, totalv, totalt;
 
 //-----------------------------------------------------------------------------
 
-static float ProjectRadius(float r, vec3_t location)
+static float RB_ProjectRadius(float r, vec3_t location)
 {
 	float  pr;
 	float  dist;
@@ -96,8 +96,8 @@ static float ProjectRadius(float r, vec3_t location)
 	vec3_t p;
 	float  projected[4];
 
-	c    = DotProduct(tr.viewParms.orientation.axis[0], tr.viewParms.orientation.origin);
-	dist = DotProduct(tr.viewParms.orientation.axis[0], location) - c;
+	c    = DotProduct(backEnd.viewParms.orientation.axis[0], backEnd.viewParms.orientation.origin);
+	dist = DotProduct(backEnd.viewParms.orientation.axis[0], location) - c;
 
 	if (dist <= 0)
 	{
@@ -108,25 +108,25 @@ static float ProjectRadius(float r, vec3_t location)
 	p[1] = Q_fabs(r);
 	p[2] = -dist;
 
-	projected[0] = p[0] * tr.viewParms.projectionMatrix[0] +
-	               p[1] * tr.viewParms.projectionMatrix[4] +
-	               p[2] * tr.viewParms.projectionMatrix[8] +
-	               tr.viewParms.projectionMatrix[12];
+	projected[0] = p[0] * backEnd.viewParms.projectionMatrix[0] +
+	               p[1] * backEnd.viewParms.projectionMatrix[4] +
+	               p[2] * backEnd.viewParms.projectionMatrix[8] +
+	               backEnd.viewParms.projectionMatrix[12];
 
-	projected[1] = p[0] * tr.viewParms.projectionMatrix[1] +
-	               p[1] * tr.viewParms.projectionMatrix[5] +
-	               p[2] * tr.viewParms.projectionMatrix[9] +
-	               tr.viewParms.projectionMatrix[13];
+	projected[1] = p[0] * backEnd.viewParms.projectionMatrix[1] +
+	               p[1] * backEnd.viewParms.projectionMatrix[5] +
+	               p[2] * backEnd.viewParms.projectionMatrix[9] +
+	               backEnd.viewParms.projectionMatrix[13];
 
-	projected[2] = p[0] * tr.viewParms.projectionMatrix[2] +
-	               p[1] * tr.viewParms.projectionMatrix[6] +
-	               p[2] * tr.viewParms.projectionMatrix[10] +
-	               tr.viewParms.projectionMatrix[14];
+	projected[2] = p[0] * backEnd.viewParms.projectionMatrix[2] +
+	               p[1] * backEnd.viewParms.projectionMatrix[6] +
+	               p[2] * backEnd.viewParms.projectionMatrix[10] +
+	               backEnd.viewParms.projectionMatrix[14];
 
-	projected[3] = p[0] * tr.viewParms.projectionMatrix[3] +
-	               p[1] * tr.viewParms.projectionMatrix[7] +
-	               p[2] * tr.viewParms.projectionMatrix[11] +
-	               tr.viewParms.projectionMatrix[15];
+	projected[3] = p[0] * backEnd.viewParms.projectionMatrix[3] +
+	               p[1] * backEnd.viewParms.projectionMatrix[7] +
+	               p[2] * backEnd.viewParms.projectionMatrix[11] +
+	               backEnd.viewParms.projectionMatrix[15];
 
 
 	pr = projected[1] / projected[3];
@@ -245,18 +245,18 @@ static int R_CullModel(trRefEntity_t *ent)
 
 /*
 =================
-R_CalcMDMLod
+RB_CalcMDMLod
 
 =================
 */
-static float R_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
+static float RB_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
 {
 	float flod;
 	float projectedRadius;
 
 	// compute projected bounding sphere and use that as a criteria for selecting LOD
 
-	projectedRadius = ProjectRadius(radius, origin);
+	projectedRadius = RB_ProjectRadius(radius, origin);
 	if (projectedRadius != 0)
 	{
 		// ri.Printf (PRINT_ALL, "projected radius: %f\n", projectedRadius);
@@ -1530,7 +1530,7 @@ void RB_MDM_SurfaceAnim(mdmSurface_t *surface)
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
 	lodRadius = frame->radius;
-	lodScale  = R_CalcMDMLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
+	lodScale  = RB_CalcMDMLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
 
 	// debug code
 	//%	lodScale = 0.15;

--- a/src/renderer/tr_animation_mds.c
+++ b/src/renderer/tr_animation_mds.c
@@ -85,7 +85,7 @@ static int totalrv, totalrt, totalv, totalt;
 
 //-----------------------------------------------------------------------------
 
-static float ProjectRadius(float r, vec3_t location)
+static float RB_ProjectRadius(float r, vec3_t location)
 {
 	float  pr;
 	float  dist;
@@ -93,8 +93,8 @@ static float ProjectRadius(float r, vec3_t location)
 	vec3_t p;
 	float  projected[4];
 
-	c    = DotProduct(tr.viewParms.orientation.axis[0], tr.viewParms.orientation.origin);
-	dist = DotProduct(tr.viewParms.orientation.axis[0], location) - c;
+	c    = DotProduct(backEnd.viewParms.orientation.axis[0], backEnd.viewParms.orientation.origin);
+	dist = DotProduct(backEnd.viewParms.orientation.axis[0], location) - c;
 
 	if (dist <= 0)
 	{
@@ -105,25 +105,25 @@ static float ProjectRadius(float r, vec3_t location)
 	p[1] = Q_fabs(r);
 	p[2] = -dist;
 
-	projected[0] = p[0] * tr.viewParms.projectionMatrix[0] +
-	               p[1] * tr.viewParms.projectionMatrix[4] +
-	               p[2] * tr.viewParms.projectionMatrix[8] +
-	               tr.viewParms.projectionMatrix[12];
+	projected[0] = p[0] * backEnd.viewParms.projectionMatrix[0] +
+	               p[1] * backEnd.viewParms.projectionMatrix[4] +
+	               p[2] * backEnd.viewParms.projectionMatrix[8] +
+	               backEnd.viewParms.projectionMatrix[12];
 
-	projected[1] = p[0] * tr.viewParms.projectionMatrix[1] +
-	               p[1] * tr.viewParms.projectionMatrix[5] +
-	               p[2] * tr.viewParms.projectionMatrix[9] +
-	               tr.viewParms.projectionMatrix[13];
+	projected[1] = p[0] * backEnd.viewParms.projectionMatrix[1] +
+	               p[1] * backEnd.viewParms.projectionMatrix[5] +
+	               p[2] * backEnd.viewParms.projectionMatrix[9] +
+	               backEnd.viewParms.projectionMatrix[13];
 
-	projected[2] = p[0] * tr.viewParms.projectionMatrix[2] +
-	               p[1] * tr.viewParms.projectionMatrix[6] +
-	               p[2] * tr.viewParms.projectionMatrix[10] +
-	               tr.viewParms.projectionMatrix[14];
+	projected[2] = p[0] * backEnd.viewParms.projectionMatrix[2] +
+	               p[1] * backEnd.viewParms.projectionMatrix[6] +
+	               p[2] * backEnd.viewParms.projectionMatrix[10] +
+	               backEnd.viewParms.projectionMatrix[14];
 
-	projected[3] = p[0] * tr.viewParms.projectionMatrix[3] +
-	               p[1] * tr.viewParms.projectionMatrix[7] +
-	               p[2] * tr.viewParms.projectionMatrix[11] +
-	               tr.viewParms.projectionMatrix[15];
+	projected[3] = p[0] * backEnd.viewParms.projectionMatrix[3] +
+	               p[1] * backEnd.viewParms.projectionMatrix[7] +
+	               p[2] * backEnd.viewParms.projectionMatrix[11] +
+	               backEnd.viewParms.projectionMatrix[15];
 
 
 	pr = projected[1] / projected[3];
@@ -228,17 +228,17 @@ static int R_CullModel(mdsHeader_t *header, trRefEntity_t *ent)
 
 /*
 =================
-R_CalcMDSLod
+RB_CalcMDSLod
 =================
 */
-float R_CalcMDSLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
+float RB_CalcMDSLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
 {
 	float flod;
 	float projectedRadius;
 
 	// compute projected bounding sphere and use that as a criteria for selecting LOD
 
-	projectedRadius = ProjectRadius(radius, origin);
+	projectedRadius = RB_ProjectRadius(radius, origin);
 	if (projectedRadius != 0)
 	{
 		float lodScale = r_lodscale->value;   // fudge factor since MDS uses a much smoother method of LOD
@@ -1327,7 +1327,7 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
 	lodRadius = frame->radius;
-	lodScale  = R_CalcMDSLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
+	lodScale  = RB_CalcMDSLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
 
 
 //DBG_SHOWTIME

--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -1585,8 +1585,6 @@ refexport_t * GetRefAPI(int apiVersion, refimport_t * rimp)
 	re.SetFog           = R_SetFog;
 
 	re.RenderScene      = RE_RenderScene;
-	re.SaveViewParms    = RE_SaveViewParms;
-	re.RestoreViewParms = RE_RestoreViewParms;
 
 	re.SetColor               = RE_SetColor;
 	re.DrawStretchPic         = RE_StretchPic;

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1576,8 +1576,6 @@ void RE_AddLightToScene(const vec3_t org, float radius, float intensity, float r
 void RE_AddCoronaToScene(const vec3_t org, float r, float g, float b, float scale, int id, qboolean visible);
 
 void RE_RenderScene(const refdef_t *fd);
-void RE_SaveViewParms(void);
-void RE_RestoreViewParms(void);
 
 /*
 =============================================================

--- a/src/renderer/tr_scene.c
+++ b/src/renderer/tr_scene.c
@@ -642,37 +642,3 @@ void RE_RenderScene(const refdef_t *fd)
 
 	tr.frontEndMsec += ri.Milliseconds() - startTime;
 }
-
-
-
-// Temp storage for saving view paramters.  Drawing the animated head in the corner
-// was creaming important view info.
-viewParms_t g_oldViewParms;
-
-/*
-================
-RE_SaveViewParms
-
-Save out the old render info to a temp place so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_SaveViewParms()
-{
-	// save old viewParms so we can return to it after the mirror view
-	g_oldViewParms = tr.viewParms;
-}
-
-/*
-================
-RE_RestoreViewParms
-
-Restore the old render info so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_RestoreViewParms()
-{
-	// This was killing the LOD computation
-	tr.viewParms = g_oldViewParms;
-}

--- a/src/renderer2/tr_animation_mdm.c
+++ b/src/renderer2/tr_animation_mdm.c
@@ -85,7 +85,7 @@ static int totalrv, totalrt, totalv, totalt;
 
 //-----------------------------------------------------------------------------
 
-static float ProjectRadius(float r, vec3_t location)
+static float RB_ProjectRadius(float r, vec3_t location)
 {
 	float  pr;
 	float  dist;
@@ -93,8 +93,8 @@ static float ProjectRadius(float r, vec3_t location)
 	vec3_t p;
 	float  projected[4];
 
-	c    = DotProduct(tr.viewParms.orientation.axis[0], tr.viewParms.orientation.origin);
-	dist = DotProduct(tr.viewParms.orientation.axis[0], location) - c;
+	c    = DotProduct(backEnd.viewParms.orientation.axis[0], backEnd.viewParms.orientation.origin);
+	dist = DotProduct(backEnd.viewParms.orientation.axis[0], location) - c;
 
 	if (dist <= 0)
 	{
@@ -105,17 +105,17 @@ static float ProjectRadius(float r, vec3_t location)
 	p[1] = Q_fabs(r);
 	p[2] = -dist;
 
-	projected[0] = p[0] * tr.viewParms.projectionMatrix[0] +
-	               p[1] * tr.viewParms.projectionMatrix[4] + p[2] * tr.viewParms.projectionMatrix[8] + tr.viewParms.projectionMatrix[12];
+	projected[0] = p[0] * backEnd.viewParms.projectionMatrix[0] +
+	               p[1] * backEnd.viewParms.projectionMatrix[4] + p[2] * backEnd.viewParms.projectionMatrix[8] + backEnd.viewParms.projectionMatrix[12];
 
-	projected[1] = p[0] * tr.viewParms.projectionMatrix[1] +
-	               p[1] * tr.viewParms.projectionMatrix[5] + p[2] * tr.viewParms.projectionMatrix[9] + tr.viewParms.projectionMatrix[13];
+	projected[1] = p[0] * backEnd.viewParms.projectionMatrix[1] +
+	               p[1] * backEnd.viewParms.projectionMatrix[5] + p[2] * backEnd.viewParms.projectionMatrix[9] + backEnd.viewParms.projectionMatrix[13];
 
-	projected[2] = p[0] * tr.viewParms.projectionMatrix[2] +
-	               p[1] * tr.viewParms.projectionMatrix[6] + p[2] * tr.viewParms.projectionMatrix[10] + tr.viewParms.projectionMatrix[14];
+	projected[2] = p[0] * backEnd.viewParms.projectionMatrix[2] +
+	               p[1] * backEnd.viewParms.projectionMatrix[6] + p[2] * backEnd.viewParms.projectionMatrix[10] + backEnd.viewParms.projectionMatrix[14];
 
-	projected[3] = p[0] * tr.viewParms.projectionMatrix[3] +
-	               p[1] * tr.viewParms.projectionMatrix[7] + p[2] * tr.viewParms.projectionMatrix[11] + tr.viewParms.projectionMatrix[15];
+	projected[3] = p[0] * backEnd.viewParms.projectionMatrix[3] +
+	               p[1] * backEnd.viewParms.projectionMatrix[7] + p[2] * backEnd.viewParms.projectionMatrix[11] + backEnd.viewParms.projectionMatrix[15];
 
 	pr = projected[1] / projected[3];
 
@@ -242,14 +242,14 @@ static int R_CullModel(trRefEntity_t *ent)
 	}
 }
 
-static float R_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
+static float RB_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
 {
 	float flod;
 	float projectedRadius;
 
 	// compute projected bounding sphere and use that as a criteria for selecting LOD
 
-	projectedRadius = ProjectRadius(radius, origin);
+	projectedRadius = RB_ProjectRadius(radius, origin);
 	if (projectedRadius != 0)
 	{
 		//ri.Printf (PRINT_ALL, "projected radius: %f\n", projectedRadius);
@@ -285,12 +285,12 @@ static float R_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, floa
 	return flod;
 }
 
-static int R_CalcMDMLodIndex(refEntity_t *ent, vec3_t origin, float radius, float modelBias, float modelScale, mdmSurfaceIntern_t *mdmSurface)
+static int RB_CalcMDMLodIndex(refEntity_t *ent, vec3_t origin, float radius, float modelBias, float modelScale, mdmSurfaceIntern_t *mdmSurface)
 {
 	float flod;
 	int   lod;
 
-	flod = R_CalcMDMLod(ent, origin, radius, modelBias, modelScale);
+	flod = RB_CalcMDMLod(ent, origin, radius, modelBias, modelScale);
 
 	//flod = r_lodTest->value;
 
@@ -1749,7 +1749,7 @@ void Tess_MDM_SurfaceAnim(mdmSurfaceIntern_t *surface)
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
 	lodRadius = frame->radius;
-	lodScale  = R_CalcMDMLod(refent, vec, lodRadius, mdm->lodBias, mdm->lodScale);
+	lodScale  = RB_CalcMDMLod(refent, vec, lodRadius, mdm->lodBias, mdm->lodScale);
 
 	// debug code
 	// lodScale = r_lodTest->value;
@@ -2259,7 +2259,7 @@ void Tess_SurfaceVBOMDMMesh(srfVBOMDMMesh_t *surface)
 
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
-	lodIndex = R_CalcMDMLodIndex(refent, vec, frame->radius, mdmModel->lodBias, mdmModel->lodScale, mdmSurface);
+	lodIndex = RB_CalcMDMLodIndex(refent, vec, frame->radius, mdmModel->lodBias, mdmModel->lodScale, mdmSurface);
 	lodIBO   = surface->ibo[lodIndex];
 
 	if (lodIBO == NULL)

--- a/src/renderer2/tr_init.c
+++ b/src/renderer2/tr_init.c
@@ -1908,8 +1908,6 @@ refexport_t * GetRefAPI(int apiVersion, refimport_t * rimp)
 	re.ClearDecals            = RE_ClearDecals;
 	re.DrawDebugPolygon       = R_DebugPolygon;
 	re.DrawDebugText          = R_DebugText;
-	re.SaveViewParms          = RE_SaveViewParms;
-	re.RestoreViewParms       = RE_RestoreViewParms;
 	re.AddCoronaToScene       = RE_AddCoronaToScene;
 	re.AddPolyBufferToScene   = RE_AddPolyBufferToScene;
 	re.SetFog                 = RE_SetFog;

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -3844,8 +3844,6 @@ void RE_AddDynamicLightToSceneQ3A(const vec3_t org, float intensity, float r, fl
 
 void RE_AddCoronaToScene(const vec3_t org, float r, float g, float b, float scale, int id, qboolean visible);
 void RE_RenderScene(const refdef_t *fd);
-void RE_SaveViewParms(void);
-void RE_RestoreViewParms(void);
 
 /*
 =============================================================

--- a/src/renderer2/tr_scene.c
+++ b/src/renderer2/tr_scene.c
@@ -753,35 +753,3 @@ void RE_RenderScene(const refdef_t *fd)
 
 	tr.frontEndMsec += ri.Milliseconds() - startTime;
 }
-
-// Temp storage for saving view paramters.  Drawing the animated head in the corner
-// was creaming important view info.
-static viewParms_t g_oldViewParms;
-
-/*
-================
-RE_SaveViewParms
-
-Save out the old render info to a temp place so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_SaveViewParms()
-{
-	// save old viewParms so we can return to it after the mirror view
-	g_oldViewParms = tr.viewParms;
-}
-
-/*
-================
-RE_RestoreViewParms
-
-Restore the old render info so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_RestoreViewParms()
-{
-	// This was killing the LOD computation
-	tr.viewParms = g_oldViewParms;
-}

--- a/src/rendererGLES/tr_animation_mdm.c
+++ b/src/rendererGLES/tr_animation_mdm.c
@@ -88,7 +88,7 @@ static int totalrv, totalrt, totalv, totalt;
 
 //-----------------------------------------------------------------------------
 
-static float ProjectRadius(float r, vec3_t location)
+static float RB_ProjectRadius(float r, vec3_t location)
 {
 	float  pr;
 	float  dist;
@@ -96,8 +96,8 @@ static float ProjectRadius(float r, vec3_t location)
 	vec3_t p;
 	float  projected[4];
 
-	c    = DotProduct(tr.viewParms.orientation.axis[0], tr.viewParms.orientation.origin);
-	dist = DotProduct(tr.viewParms.orientation.axis[0], location) - c;
+	c    = DotProduct(backEnd.viewParms.orientation.axis[0], backEnd.viewParms.orientation.origin);
+	dist = DotProduct(backEnd.viewParms.orientation.axis[0], location) - c;
 
 	if (dist <= 0)
 	{
@@ -108,25 +108,25 @@ static float ProjectRadius(float r, vec3_t location)
 	p[1] = Q_fabs(r);
 	p[2] = -dist;
 
-	projected[0] = p[0] * tr.viewParms.projectionMatrix[0] +
-	               p[1] * tr.viewParms.projectionMatrix[4] +
-	               p[2] * tr.viewParms.projectionMatrix[8] +
-	               tr.viewParms.projectionMatrix[12];
+	projected[0] = p[0] * backEnd.viewParms.projectionMatrix[0] +
+	               p[1] * backEnd.viewParms.projectionMatrix[4] +
+	               p[2] * backEnd.viewParms.projectionMatrix[8] +
+	               backEnd.viewParms.projectionMatrix[12];
 
-	projected[1] = p[0] * tr.viewParms.projectionMatrix[1] +
-	               p[1] * tr.viewParms.projectionMatrix[5] +
-	               p[2] * tr.viewParms.projectionMatrix[9] +
-	               tr.viewParms.projectionMatrix[13];
+	projected[1] = p[0] * backEnd.viewParms.projectionMatrix[1] +
+	               p[1] * backEnd.viewParms.projectionMatrix[5] +
+	               p[2] * backEnd.viewParms.projectionMatrix[9] +
+	               backEnd.viewParms.projectionMatrix[13];
 
-	projected[2] = p[0] * tr.viewParms.projectionMatrix[2] +
-	               p[1] * tr.viewParms.projectionMatrix[6] +
-	               p[2] * tr.viewParms.projectionMatrix[10] +
-	               tr.viewParms.projectionMatrix[14];
+	projected[2] = p[0] * backEnd.viewParms.projectionMatrix[2] +
+	               p[1] * backEnd.viewParms.projectionMatrix[6] +
+	               p[2] * backEnd.viewParms.projectionMatrix[10] +
+	               backEnd.viewParms.projectionMatrix[14];
 
-	projected[3] = p[0] * tr.viewParms.projectionMatrix[3] +
-	               p[1] * tr.viewParms.projectionMatrix[7] +
-	               p[2] * tr.viewParms.projectionMatrix[11] +
-	               tr.viewParms.projectionMatrix[15];
+	projected[3] = p[0] * backEnd.viewParms.projectionMatrix[3] +
+	               p[1] * backEnd.viewParms.projectionMatrix[7] +
+	               p[2] * backEnd.viewParms.projectionMatrix[11] +
+	               backEnd.viewParms.projectionMatrix[15];
 
 
 	pr = projected[1] / projected[3];
@@ -245,18 +245,18 @@ static int R_CullModel(trRefEntity_t *ent)
 
 /*
 =================
-R_CalcMDMLod
+RB_CalcMDMLod
 
 =================
 */
-static float R_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
+static float RB_CalcMDMLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
 {
 	float flod;
 	float projectedRadius;
 
 	// compute projected bounding sphere and use that as a criteria for selecting LOD
 
-	projectedRadius = ProjectRadius(radius, origin);
+	projectedRadius = RB_ProjectRadius(radius, origin);
 	if (projectedRadius != 0)
 	{
 		// ri.Printf (PRINT_ALL, "projected radius: %f\n", projectedRadius);
@@ -1534,7 +1534,7 @@ void RB_MDM_SurfaceAnim(mdmSurface_t *surface)
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
 	lodRadius = frame->radius;
-	lodScale  = R_CalcMDMLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
+	lodScale  = RB_CalcMDMLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
 
 	// debug code
 	//%	lodScale = 0.15;

--- a/src/rendererGLES/tr_animation_mds.c
+++ b/src/rendererGLES/tr_animation_mds.c
@@ -85,7 +85,7 @@ static int totalrv, totalrt, totalv, totalt;
 
 //-----------------------------------------------------------------------------
 
-static float ProjectRadius(float r, vec3_t location)
+static float RB_ProjectRadius(float r, vec3_t location)
 {
 	float  pr;
 	float  dist;
@@ -93,8 +93,8 @@ static float ProjectRadius(float r, vec3_t location)
 	vec3_t p;
 	float  projected[4];
 
-	c    = DotProduct(tr.viewParms.orientation.axis[0], tr.viewParms.orientation.origin);
-	dist = DotProduct(tr.viewParms.orientation.axis[0], location) - c;
+	c    = DotProduct(backEnd.viewParms.orientation.axis[0], backEnd.viewParms.orientation.origin);
+	dist = DotProduct(backEnd.viewParms.orientation.axis[0], location) - c;
 
 	if (dist <= 0)
 	{
@@ -105,25 +105,25 @@ static float ProjectRadius(float r, vec3_t location)
 	p[1] = Q_fabs(r);
 	p[2] = -dist;
 
-	projected[0] = p[0] * tr.viewParms.projectionMatrix[0] +
-	               p[1] * tr.viewParms.projectionMatrix[4] +
-	               p[2] * tr.viewParms.projectionMatrix[8] +
-	               tr.viewParms.projectionMatrix[12];
+	projected[0] = p[0] * backEnd.viewParms.projectionMatrix[0] +
+	               p[1] * backEnd.viewParms.projectionMatrix[4] +
+	               p[2] * backEnd.viewParms.projectionMatrix[8] +
+	               backEnd.viewParms.projectionMatrix[12];
 
-	projected[1] = p[0] * tr.viewParms.projectionMatrix[1] +
-	               p[1] * tr.viewParms.projectionMatrix[5] +
-	               p[2] * tr.viewParms.projectionMatrix[9] +
-	               tr.viewParms.projectionMatrix[13];
+	projected[1] = p[0] * backEnd.viewParms.projectionMatrix[1] +
+	               p[1] * backEnd.viewParms.projectionMatrix[5] +
+	               p[2] * backEnd.viewParms.projectionMatrix[9] +
+	               backEnd.viewParms.projectionMatrix[13];
 
-	projected[2] = p[0] * tr.viewParms.projectionMatrix[2] +
-	               p[1] * tr.viewParms.projectionMatrix[6] +
-	               p[2] * tr.viewParms.projectionMatrix[10] +
-	               tr.viewParms.projectionMatrix[14];
+	projected[2] = p[0] * backEnd.viewParms.projectionMatrix[2] +
+	               p[1] * backEnd.viewParms.projectionMatrix[6] +
+	               p[2] * backEnd.viewParms.projectionMatrix[10] +
+	               backEnd.viewParms.projectionMatrix[14];
 
-	projected[3] = p[0] * tr.viewParms.projectionMatrix[3] +
-	               p[1] * tr.viewParms.projectionMatrix[7] +
-	               p[2] * tr.viewParms.projectionMatrix[11] +
-	               tr.viewParms.projectionMatrix[15];
+	projected[3] = p[0] * backEnd.viewParms.projectionMatrix[3] +
+	               p[1] * backEnd.viewParms.projectionMatrix[7] +
+	               p[2] * backEnd.viewParms.projectionMatrix[11] +
+	               backEnd.viewParms.projectionMatrix[15];
 
 
 	pr = projected[1] / projected[3];
@@ -231,17 +231,17 @@ static int R_CullModel(mdsHeader_t *header, trRefEntity_t *ent)
 
 /*
 =================
-R_CalcMDSLod
+RB_CalcMDSLod
 =================
 */
-float R_CalcMDSLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
+float RB_CalcMDSLod(refEntity_t *refent, vec3_t origin, float radius, float modelBias, float modelScale)
 {
 	float flod;
 	float projectedRadius;
 
 	// compute projected bounding sphere and use that as a criteria for selecting LOD
 
-	projectedRadius = ProjectRadius(radius, origin);
+	projectedRadius = RB_ProjectRadius(radius, origin);
 	if (projectedRadius != 0)
 	{
 		float lodScale = r_lodscale->value;   // fudge factor since MDS uses a much smoother method of LOD
@@ -1335,7 +1335,7 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 	// TODO: lerp the radius and origin
 	VectorAdd(refent->origin, frame->localOrigin, vec);
 	lodRadius = frame->radius;
-	lodScale  = R_CalcMDSLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
+	lodScale  = RB_CalcMDSLod(refent, vec, lodRadius, header->lodBias, header->lodScale);
 
 
 //DBG_SHOWTIME

--- a/src/rendererGLES/tr_init.c
+++ b/src/rendererGLES/tr_init.c
@@ -1554,8 +1554,6 @@ refexport_t * GetRefAPI(int apiVersion, refimport_t * rimp)
 	re.SetFog           = R_SetFog;
 
 	re.RenderScene      = RE_RenderScene;
-	re.SaveViewParms    = RE_SaveViewParms;
-	re.RestoreViewParms = RE_RestoreViewParms;
 
 	re.SetColor               = RE_SetColor;
 	re.DrawStretchPic         = RE_StretchPic;

--- a/src/rendererGLES/tr_local.h
+++ b/src/rendererGLES/tr_local.h
@@ -1605,8 +1605,6 @@ void RE_AddLightToScene(const vec3_t org, float radius, float intensity, float r
 void RE_AddCoronaToScene(const vec3_t org, float r, float g, float b, float scale, int id, qboolean visible);
 
 void RE_RenderScene(const refdef_t *fd);
-void RE_SaveViewParms(void);
-void RE_RestoreViewParms(void);
 
 /*
 =============================================================

--- a/src/rendererGLES/tr_scene.c
+++ b/src/rendererGLES/tr_scene.c
@@ -642,37 +642,3 @@ void RE_RenderScene(const refdef_t *fd)
 
 	tr.frontEndMsec += ri.Milliseconds() - startTime;
 }
-
-
-
-// Temp storage for saving view paramters.  Drawing the animated head in the corner
-// was creaming important view info.
-viewParms_t g_oldViewParms;
-
-/*
-================
-RE_SaveViewParms
-
-Save out the old render info to a temp place so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_SaveViewParms()
-{
-	// save old viewParms so we can return to it after the mirror view
-	g_oldViewParms = tr.viewParms;
-}
-
-/*
-================
-RE_RestoreViewParms
-
-Restore the old render info so we don't kill the LOD system
-when we do a second render.
-================
-*/
-void RE_RestoreViewParms()
-{
-	// This was killing the LOD computation
-	tr.viewParms = g_oldViewParms;
-}

--- a/src/renderercommon/tr_public.h
+++ b/src/renderercommon/tr_public.h
@@ -87,9 +87,6 @@ typedef struct
 	void (*SetFog)(int fogvar, int var1, int var2, float r, float g, float b, float density);
 	void (*RenderScene)(const refdef_t *fd);
 
-	void (*SaveViewParms)(void);
-	void (*RestoreViewParms)(void);
-
 	void (*SetColor)(const float *rgba);        // NULL = 1,1,1,1
 	void (*DrawStretchPic)(float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader);          // 0 = white
 	void (*DrawRotatedPic)(float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader, float angle);         // NERVE - SMF


### PR DESCRIPTION
MDS/MDM level of detail (LOD) backend code uses frontend data (tr.viewParms). This commit fixes makes it use the correct backend data (backEnd.viewParms). This issue is probably why the save/restore viewparms cgame system calls were added in ET, which hide the issue.

ProjectRadius was renamed to RB_ProjectRadius in the MDS/MDM code to make it more obviously different from MD3/MDC/etc ProjectRadius which is used by frontend.
## How to test

To witness the MDS/MDM level of detail issue, disable the syscalls in cl_cgame.c;

``` c
    case CG_R_SAVEVIEWPARMS:
-       re.SaveViewParms();
+       //re.SaveViewParms();
        return 0;
    case CG_R_RESTOREVIEWPARMS:
-       re.RestoreViewParms();
+       //re.RestoreViewParms();
        return 0;
```

then run `devmap oasis`, select class in limbo menu, `cg_thirdPerson 1`, `r_bonesDebug 4`. Some places the LOD percent will start rapidly dropping (and is also visible on the player body), such as around `setviewpos 5882 7158 -343 0`.

After applying the changes in the commit, the LOD does not drop unexpectedly.
## Remove hack

ET added trap_R_SaveViewParms and trap_R_RestoreViewParms, which according to the comments exists "so we don't kill the LOD system" when drawing head on the HUD.

Now that the LOD issue is fixed, ETL could probably remove the client and renderer code for RE_SaveViewParms/RE_RestoreViewParms.
