### PR TITLE
renderers: fix decal projector culling

### DIFF
--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -150,6 +150,12 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 		return;
 	}
 
+	if (r_numDecalProjectors >= MAX_DECAL_PROJECTORS)
+	{
+		Ren_Print("WARNING: RE_ProjectDecal() Max decal projectors reached (%d)\n", MAX_DECAL_PROJECTORS);
+		return;
+	}
+
 	// dummy check
 	if (numPoints != 1 && numPoints != 3 && numPoints != 4)
 	{
@@ -273,13 +279,6 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	temp.radius  = VectorLength(xyz);
 	temp.radius2 = temp.radius * temp.radius;
 
-	// frustum cull the projector (fixme: this uses a stale frustum!)
-	if (R_CullPointAndRadius(temp.center, temp.radius) == CULL_OUT)
-	{
-		Ren_Print("WARNING: RE_ProjectDecal() R_CullPointAndRadius fails\n");
-		return;
-	}
-
 	// make the front plane
 	if (!PlaneFromPoints(temp.planes[0], dv[0].xyz, dv[1].xyz, dv[2].xyz))
 	{
@@ -304,7 +303,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	// create a new projector
-	dp = &tr.refdef.decalProjectors[r_numDecalProjectors & DECAL_PROJECTOR_MASK];
+	dp = &tr.refdef.decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
 
 	// we have a winner
@@ -959,12 +958,6 @@ void R_CullDecalProjectors(void)
 	int              i, numDecalProjectors = 0, decalBits = 0;
 	decalProjector_t *dp;
 
-	// limit
-	if (tr.refdef.numDecalProjectors > MAX_DECAL_PROJECTORS)
-	{
-		tr.refdef.numDecalProjectors = MAX_DECAL_PROJECTORS;
-	}
-
 	// walk decal projector list
 	for (i = 0, dp = tr.refdef.decalProjectors; i < tr.refdef.numDecalProjectors; i++, dp++)
 	{
@@ -974,8 +967,20 @@ void R_CullDecalProjectors(void)
 		}
 		else
 		{
-			numDecalProjectors = i + 1;
-			decalBits         |= (1 << i);
+			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
+			{
+				// put all active projectors at the beginning
+				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+			}
+
+			decalBits |= (1 << numDecalProjectors);
+			numDecalProjectors++;
+
+			// bitmask limit
+			if (numDecalProjectors == 32)
+			{
+				break;
+			}
 		}
 	}
 

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1784,8 +1784,7 @@ typedef enum
 #define MAX_POLYVERTS   32768 // was 8192
 
 // max decal projectors per frame, each can generate lots of polys
-#define MAX_DECAL_PROJECTORS    32  // uses bitmasks, don't increase
-#define DECAL_PROJECTOR_MASK    (MAX_DECAL_PROJECTORS - 1)
+#define MAX_DECAL_PROJECTORS    512 // includes decal projectors that will be culled out, hard limited to 32 active projectors because of bitmasks.
 #define MAX_DECALS              1024
 
 // all of the information needed by the back end must be

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -4123,8 +4123,7 @@ typedef enum
 } renderCommand_t;
 
 // max decal projectors per frame, each can generate lots of polys
-#define MAX_DECAL_PROJECTORS    32  // uses bitmasks, don't increase
-#define DECAL_PROJECTOR_MASK    (MAX_DECAL_PROJECTORS - 1)
+#define MAX_DECAL_PROJECTORS    512 // includes decal projectors that will be culled out, hard limited to 32 active projectors because of bitmasks.
 #define MAX_DECALS              1024
 #define DECAL_MASK              (MAX_DECALS - 1)
 

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -150,6 +150,12 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 		return;
 	}
 
+	if (r_numDecalProjectors >= MAX_DECAL_PROJECTORS)
+	{
+		ri.Printf(PRINT_WARNING, "WARNING: RE_ProjectDecal() Max decal projectors reached (%d)\n", MAX_DECAL_PROJECTORS);
+		return;
+	}
+
 	/* dummy check */
 	if (numPoints != 1 && numPoints != 3 && numPoints != 4)
 	{
@@ -267,12 +273,6 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	temp.radius  = VectorLength(xyz);
 	temp.radius2 = temp.radius * temp.radius;
 
-	/* frustum cull the projector (fixme: this uses a stale frustum!) */
-	if (R_CullPointAndRadius(temp.center, temp.radius) == CULL_OUT)
-	{
-		return;
-	}
-
 	/* make the front plane */
 	if (!PlaneFromPoints(temp.planes[0], dv[0].xyz, dv[1].xyz, dv[2].xyz))
 	{
@@ -295,7 +295,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	/* create a new projector */
-	dp = &tr.refdef.decalProjectors[r_numDecalProjectors & DECAL_PROJECTOR_MASK];
+	dp = &tr.refdef.decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
 
 	/* we have a winner */
@@ -951,12 +951,6 @@ void R_CullDecalProjectors(void)
 	int              i, numDecalProjectors, decalBits;
 	decalProjector_t *dp;
 
-	/* limit */
-	if (tr.refdef.numDecalProjectors > MAX_DECAL_PROJECTORS)
-	{
-		tr.refdef.numDecalProjectors = MAX_DECAL_PROJECTORS;
-	}
-
 	/* walk decal projector list */
 	numDecalProjectors = 0;
 	decalBits          = 0;
@@ -968,8 +962,20 @@ void R_CullDecalProjectors(void)
 		}
 		else
 		{
-			numDecalProjectors = i + 1;
-			decalBits         |= (1 << i);
+			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
+			{
+				/* put all active projectors at the beginning */
+				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+			}
+
+			decalBits |= (1 << numDecalProjectors);
+			numDecalProjectors++;
+
+			/* bitmask limit */
+			if (numDecalProjectors == 32)
+			{
+				break;
+			}
 		}
 	}
 

--- a/src/rendererGLES/tr_local.h
+++ b/src/rendererGLES/tr_local.h
@@ -1813,8 +1813,7 @@ typedef enum
 #define MAX_POLYVERTS   32768 // was 8192
 
 // max decal projectors per frame, each can generate lots of polys
-#define MAX_DECAL_PROJECTORS    32  // uses bitmasks, don't increase
-#define DECAL_PROJECTOR_MASK    (MAX_DECAL_PROJECTORS - 1)
+#define MAX_DECAL_PROJECTORS    512 // includes decal projectors that will be culled out, hard limited to 32 active projectors because of bitmasks.
 #define MAX_DECALS              1024
 
 // all of the information needed by the back end must be


### PR DESCRIPTION
Fix for http://www.etlegacy.com/issues/557

The R_CullPointAndRadius call in RE_ProjectDecal has a comment which says "frustum cull the projector (fixme: this uses a stale frustum!)". By removing the save/restore viewparms before/after drawing head model scene, it now uses the head scene frustum instead of stale world frustum.

It's impossible to have the correct frustum in RE_ProjectDecal. The correct frustum cannot be generated before trap_R_RenderScene is called because the renderer doesn't have the view origin/axis, etc. So need to change the code to hold all the decal projectors and then cull them later in R_CullDecalProjectors.

---

Instead of using stale frustum to cull decal projects in RE_ProjectDecal (which no longer works now that save/restore viewparms was removed) and then culling them again with the current frustum; store up to 512
decal projectors per-frame and cull them later using the current frustum.

32-bit bitmasks are used to mark which projectors affect a surface, so in R_CullDecalProjectors put (up to 32) active decal projectors at the beginning of array.

512 decal projectors per-frame was picked at random. Might be excess or too low.

---

I merge the code into GLES and opengl2, but didn't compile it.
