### PR TITLE
renderers: allocate less poly buffers and fix max checks

### DIFF
--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1787,8 +1787,6 @@ typedef enum
 #define MAX_DECAL_PROJECTORS    512 // includes decal projectors that will be culled out, hard limited to 32 active projectors because of bitmasks.
 #define MAX_DECALS              1024
 
-#define MAX_POLYBUFFERS	4096
-
 // all of the information needed by the back end must be
 // contained in a backEndData_t.
 typedef struct
@@ -1798,7 +1796,7 @@ typedef struct
 	corona_t coronas[MAX_CORONAS];
 	trRefEntity_t entities[MAX_REFENTITIES];
 	srfPoly_t *polys; // [MAX_POLYS];
-	srfPolyBuffer_t polybuffers[MAX_POLYBUFFERS];
+	srfPolyBuffer_t polybuffers[MAX_POLYS];
 	polyVert_t *polyVerts; // [MAX_POLYVERTS];
 	decalProjector_t decalProjectors[MAX_DECAL_PROJECTORS];
 	srfDecal_t decals[MAX_DECALS];

--- a/src/renderer/tr_scene.c
+++ b/src/renderer/tr_scene.c
@@ -340,9 +340,9 @@ void RE_AddPolyBufferToScene(polyBuffer_t *pPolyBuffer)
 	vec3_t          bounds[2];
 	int             i;
 
-	if (r_numpolybuffers >= MAX_POLYBUFFERS)
+	if (r_numpolybuffers >= r_maxpolys->integer)
 	{
-		Ren_Warning("WARNING RE_AddPolyBufferToScene: MAX_POLYBUFFERS (%d) reached\n", MAX_POLYBUFFERS);
+		Ren_Warning("WARNING RE_AddPolyBufferToScene: r_maxpolys reached\n");
 		return;
 	}
 

--- a/src/renderer2/tr_init.c
+++ b/src/renderer2/tr_init.c
@@ -1701,6 +1701,7 @@ void R_Init(void)
 	backEndData              = (backEndData_t *) ri.Hunk_Alloc(sizeof(*backEndData), h_low);
 	backEndData->polys       = (srfPoly_t *) ri.Hunk_Alloc(r_maxpolys->integer * sizeof(srfPoly_t), h_low);
 	backEndData->polyVerts   = (polyVert_t *) ri.Hunk_Alloc(r_maxpolyverts->integer * sizeof(polyVert_t), h_low);
+	backEndData->polybuffers = (srfPolyBuffer_t *) ri.Hunk_Alloc(r_maxpolys->integer * sizeof(srfPolyBuffer_t), h_low);
 
 	R_InitNextFrame();
 

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -4127,8 +4127,6 @@ typedef enum
 #define MAX_DECALS              1024
 #define DECAL_MASK              (MAX_DECALS - 1)
 
-#define MAX_POLYBUFFERS	4096
-
 // all of the information needed by the back end must be
 // contained in a backEndData_t.
 typedef struct
@@ -4143,7 +4141,7 @@ typedef struct
 
 	srfPoly_t *polys;           //[MAX_POLYS];
 	polyVert_t *polyVerts;      //[MAX_POLYVERTS];
-	srfPolyBuffer_t polybuffers[MAX_POLYBUFFERS];
+	srfPolyBuffer_t *polybuffers; //[MAX_POLYS];
 
 	decalProjector_t decalProjectors[MAX_DECAL_PROJECTORS];
 	srfDecal_t decals[MAX_DECALS];

--- a/src/renderer2/tr_scene.c
+++ b/src/renderer2/tr_scene.c
@@ -296,7 +296,7 @@ void RE_AddPolyBufferToScene(polyBuffer_t *pPolyBuffer)
 		return;
 	}
 
-	if (r_numPolybuffers >= MAX_POLYBUFFERS)
+	if (r_numPolybuffers >= r_maxpolyverts->integer)
 	{
 		return;
 	}

--- a/src/rendererGLES/tr_local.h
+++ b/src/rendererGLES/tr_local.h
@@ -1816,8 +1816,6 @@ typedef enum
 #define MAX_DECAL_PROJECTORS    512 // includes decal projectors that will be culled out, hard limited to 32 active projectors because of bitmasks.
 #define MAX_DECALS              1024
 
-#define MAX_POLYBUFFERS	4096
-
 // all of the information needed by the back end must be
 // contained in a backEndData_t.
 typedef struct
@@ -1827,7 +1825,7 @@ typedef struct
 	corona_t coronas[MAX_CORONAS];
 	trRefEntity_t entities[MAX_ENTITIES];
 	srfPoly_t *polys; // [MAX_POLYS];
-	srfPolyBuffer_t polybuffers[MAX_POLYBUFFERS];
+	srfPolyBuffer_t polybuffers[MAX_POLYS];
 	polyVert_t *polyVerts; // [MAX_POLYVERTS];
 	decalProjector_t decalProjectors[MAX_DECAL_PROJECTORS];
 	srfDecal_t decals[MAX_DECALS];

--- a/src/rendererGLES/tr_scene.c
+++ b/src/rendererGLES/tr_scene.c
@@ -340,9 +340,9 @@ void RE_AddPolyBufferToScene(polyBuffer_t *pPolyBuffer)
 	vec3_t          bounds[2];
 	int             i;
 
-	if (r_numpolybuffers >= MAX_POLYBUFFERS)
+	if (r_numpolybuffers >= r_maxpolys->integer)
 	{
-		ri.Printf(PRINT_WARNING, "WARNING RE_AddPolyBufferToScene: MAX_POLYBUFFERS (%d) reached\n", MAX_POLYBUFFERS);
+		ri.Printf(PRINT_WARNING, "WARNING RE_AddPolyBufferToScene: r_maxpolys reached\n");
 		return;
 	}
 


### PR DESCRIPTION
Reverts etlegacy/etlegacy#88
