### PR TITLE
renderer: fix RE_AddPolysToScene max checks in gl1/gles

### DIFF
--- a/src/renderer/tr_scene.c
+++ b/src/renderer/tr_scene.c
@@ -159,7 +159,7 @@ void RE_AddPolyToScene(qhandle_t hShader, int numVerts, const polyVert_t *verts)
 		return;
 	}
 
-	if (((r_numpolyverts + numVerts) >= r_maxpolys->integer) || (r_numpolys >= r_maxpolyverts->integer))
+	if (((r_numpolyverts + numVerts) >= r_maxpolyverts->integer) || (r_numpolys >= r_maxpolys->integer))
 	{
 		Ren_Developer("WARNING RE_AddPolyToScene: r_maxpolyverts or r_maxpolys reached\n");
 		return;
@@ -240,14 +240,14 @@ void RE_AddPolysToScene(qhandle_t hShader, int numVerts, const polyVert_t *verts
 
 	for (j = 0; j < numPolys; j++)
 	{
-		if (r_numpolyverts + numVerts >= r_maxpolys->integer)
+		if (r_numpolyverts + numVerts >= r_maxpolyverts->integer)
 		{
-			Ren_Developer("WARNING RE_AddPolysToScene: r_maxpolys[%i] reached. r_numpolyverts: %i - numVerts: %i - numPolys %i - shader %i\n", r_maxpolys->integer, r_numpolyverts, numVerts, numPolys, hShader);
+			Ren_Developer("WARNING RE_AddPolysToScene: r_maxpolyverts[%i] reached. r_numpolyverts: %i - numVerts: %i - numPolys %i - shader %i\n", r_maxpolyverts->integer, r_numpolyverts, numVerts, numPolys, hShader);
 			return;
 		}
-		if (r_numpolys >= r_maxpolyverts->integer)
+		if (r_numpolys >= r_maxpolys->integer)
 		{
-			Ren_Developer("WARNING RE_AddPolysToScene: r_maxpolyverts[%i] reached. r_numpolys: %i\n", r_maxpolyverts->integer, r_numpolys);
+			Ren_Developer("WARNING RE_AddPolysToScene: r_maxpolys[%i] reached. r_numpolys: %i\n", r_maxpolys->integer, r_numpolys);
 			return;
 		}
 

--- a/src/rendererGLES/tr_scene.c
+++ b/src/rendererGLES/tr_scene.c
@@ -159,7 +159,7 @@ void RE_AddPolyToScene(qhandle_t hShader, int numVerts, const polyVert_t *verts)
 		return;
 	}
 
-	if (((r_numpolyverts + numVerts) >= r_maxpolys->integer) || (r_numpolys >= r_maxpolyverts->integer))
+	if (((r_numpolyverts + numVerts) >= r_maxpolyverts->integer) || (r_numpolys >= r_maxpolys->integer))
 	{
 		ri.Printf(PRINT_DEVELOPER, "WARNING RE_AddPolyToScene: r_maxpolyverts or r_maxpolys reached\n");
 		return;
@@ -240,14 +240,14 @@ void RE_AddPolysToScene(qhandle_t hShader, int numVerts, const polyVert_t *verts
 
 	for (j = 0; j < numPolys; j++)
 	{
-		if (r_numpolyverts + numVerts >= r_maxpolys->integer)
+		if (r_numpolyverts + numVerts >= r_maxpolyverts->integer)
 		{
-			ri.Printf(PRINT_DEVELOPER, "WARNING RE_AddPolysToScene: r_maxpolys[%i] reached. r_numpolyverts: %i - numVerts: %i\n", r_maxpolys->integer, r_numpolyverts, numVerts);
+			ri.Printf(PRINT_DEVELOPER, "WARNING RE_AddPolysToScene: r_maxpolyverts[%i] reached. r_numpolyverts: %i - numVerts: %i - numPolys %i - shader %i\n", r_maxpolyverts->integer, r_numpolyverts, numVerts, numPolys, hShader);
 			return;
 		}
-		if (r_numpolys >= r_maxpolyverts->integer)
+		if (r_numpolys >= r_maxpolys->integer)
 		{
-			ri.Printf(PRINT_DEVELOPER, "WARNING RE_AddPolysToScene: r_maxpolyverts[%i] reached. r_numpolys: %i\n", r_maxpolyverts->integer, r_numpolys);
+			ri.Printf(PRINT_DEVELOPER, "WARNING RE_AddPolysToScene: r_maxpolys[%i] reached. r_numpolys: %i\n", r_maxpolys->integer, r_numpolys);
 			return;
 		}
 


### PR DESCRIPTION
polys and polyverts max checks are reversed in gl1/gles. gl2 is not affected.
