### PR TITLE
client and server: Some fixes with userinfo in engine.

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2156,7 +2156,7 @@ CL_CheckUserinfo
 void CL_CheckUserinfo(void)
 {
 	// don't add reliable commands when not yet connected
-	if (cls.state < CA_CHALLENGING)
+	if (cls.state < CA_CONNECTED)
 	{
 		return;
 	}
@@ -3165,7 +3165,7 @@ void CL_Init(void)
 	Cmd_AddCommand("setRecommended", CL_SetRecommended_f);
 
 	// we eat these commands to prevent exploits
-	Cmd_AddCommand("userinfo", CL_EatMe_f);
+	//Cmd_AddCommand("userinfo", CL_EatMe_f);
 
 	Cmd_AddCommand("wav_record", CL_WavRecord_f);
 	Cmd_AddCommand("wav_stoprecord", CL_WavStopRecord_f);

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -1446,9 +1446,16 @@ void SV_UserinfoChanged(client_t *cl)
 
 void SV_UpdateUserinfo_f(client_t *cl)
 {
+	char *arg = Cmd_Argv(1);
+	// Stop random empty /userinfo calls without hurting anything
+	if (!arg || !*arg)
+	{
+		return;
+	}
+
 	if ((sv_floodProtect->integer) && (cl->state >= CS_ACTIVE) && (svs.time < cl->nextReliableUserTime))
 	{
-		Q_strncpyz(cl->userinfobuffer, Cmd_Argv(1), sizeof(cl->userinfobuffer));
+		Q_strncpyz(cl->userinfobuffer, arg, sizeof(cl->userinfobuffer));
 		SV_SendServerCommand(cl, "print \"^7Command ^1delayed^7 due to sv_floodprotect.\"");
 		return;
 	}
@@ -1458,10 +1465,10 @@ void SV_UpdateUserinfo_f(client_t *cl)
 	// Save userinfo changes to demo (also in SV_SetUserinfo() in sv_init.c)
 	if (sv.demoState == DS_RECORDING)
 	{
-		SV_DemoWriteClientUserinfo(cl, Cmd_Argv(1));
+		SV_DemoWriteClientUserinfo(cl, arg);
 	}
 
-	Q_strncpyz(cl->userinfo, Cmd_Argv(1), sizeof(cl->userinfo));
+	Q_strncpyz(cl->userinfo, arg, sizeof(cl->userinfo));
 
 	SV_UserinfoChanged(cl);
 	// call prog code to allow overrides

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -1089,7 +1089,7 @@ void SV_CheckClientUserinfoTimer(void)
 		if ((sv_floodProtect->integer) && (svs.time >= cl->nextReliableUserTime) && (cl->state >= CS_ACTIVE) && (cl->userinfobuffer[0] != 0))
 		{
 			// We have something in the buffer and it's time to process it
-			sprintf(bigbuffer, "userinfo \"%s\"", cl->userinfobuffer);
+			Com_sprintf(bigbuffer, sizeof(bigbuffer), "userinfo \"%s\"", cl->userinfobuffer);
 
 			Cmd_TokenizeString(bigbuffer);
 			SV_UpdateUserinfo_f(cl);


### PR DESCRIPTION
Merge ioquake/ioq3@86c41d39daee32393d5d48f7fe099bbfd18b0fa7 (Fix sending reliable commands before being connected, patch by Eugene C.)
Stop eating userinfo cmd in client.  With the source open, it serves little purpose leaving it there.
Prevent users executing userinfo cmd with no arguments.
Use Com_sprintf in SV_CheckClientUserinfoTimer.
