### PR TITLE
Fix decals when there are world multiple scenes

### DIFF
--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -143,13 +143,6 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	int              i;
 	decalProjector_t *dp, temp;
 
-	// first frame rendered does not have a valid decals list
-	if (tr.refdef.decalProjectors == NULL)
-	{
-		Ren_Print("WARNING: RE_ProjectDecal() tr.refdef.decalProjectors == NULL\n");
-		return;
-	}
-
 	if (r_numDecalProjectors >= MAX_DECAL_PROJECTORS)
 	{
 		Ren_Print("WARNING: RE_ProjectDecal() Max decal projectors reached (%d)\n", MAX_DECAL_PROJECTORS);
@@ -189,7 +182,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	temp.color[2]      = color[2] * 255;
 	temp.color[3]      = color[3] * 255;
 	temp.numPlanes     = numPoints + 2;
-	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime;
+	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime; // fixme: stale refdef time
 	temp.fadeEndTime   = temp.fadeStartTime + fadeTime;
 
 	// set up decal texcoords (fixme: support arbitrary projector st coordinates in trapcall)
@@ -302,7 +295,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	// create a new projector
-	dp = &tr.refdef.decalProjectors[r_numDecalProjectors];
+	dp = &backEndData->decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
 
 	// we have a winner

--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -35,6 +35,7 @@
 #include "tr_local.h"
 
 extern int r_numDecalProjectors;
+extern int r_firstSceneDecal;
 
 typedef struct decalVert_s
 {
@@ -872,7 +873,7 @@ void R_AddDecalSurface(decal_t *decal)
 	srfGeneric_t *gen;
 
 	// early outs
-	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCount || tr.refdef.numDecals >= MAX_DECALS)
+	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCount || r_firstSceneDecal + tr.refdef.numDecals >= MAX_DECALS)
 	{
 		return;
 	}

--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -183,8 +183,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	// basic setup
-	temp.shader        = R_GetShaderByHandle(hShader); // debug code
-	temp.numPlanes     = temp.shader->entityMergable;
+	temp.shader        = R_GetShaderByHandle(hShader);
 	temp.color[0]      = color[0] * 255;
 	temp.color[1]      = color[1] * 255;
 	temp.color[2]      = color[2] * 255;

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -463,6 +463,7 @@ typedef struct decalProjector_s
 	int numPlanes;                  // either 5 or 6, for quad or triangle projectors
 	vec4_t planes[6];
 	vec4_t texMat[3][2];
+	int projectorNum;				// global identifier
 }
 decalProjector_t;
 
@@ -866,6 +867,8 @@ typedef struct decal_s
 	int fogIndex;
 	int numVerts;
 	polyVert_t verts[MAX_DECAL_VERTS];
+	int projectorNum;
+	int frameAdded; // need to keep decal for at least one frame so we know not to reproject it in later views
 }
 decal_t;
 

--- a/src/renderer/tr_scene.c
+++ b/src/renderer/tr_scene.c
@@ -57,7 +57,6 @@ int r_numpolybuffers;
 int r_firstSceneDecalProjector;
 int r_numDecalProjectors;
 int r_firstSceneDecal;
-int r_numDecals;
 
 int skyboxportal;
 
@@ -88,7 +87,6 @@ void R_InitNextFrame(void)
 	// decals
 	r_numDecalProjectors       = 0;
 	r_firstSceneDecalProjector = 0;
-	r_numDecals                = 0;
 	r_firstSceneDecal          = 0;
 }
 
@@ -589,7 +587,7 @@ void RE_RenderScene(const refdef_t *fd)
 	tr.refdef.numDecalProjectors = r_numDecalProjectors - r_firstSceneDecalProjector;
 	tr.refdef.decalProjectors    = &backEndData->decalProjectors[r_firstSceneDecalProjector];
 
-	tr.refdef.numDecals = r_numDecals - r_firstSceneDecal;
+	tr.refdef.numDecals = 0;
 	tr.refdef.decals    = &backEndData->decals[r_firstSceneDecal];
 
 	// a single frame may have multiple scenes draw inside it --
@@ -625,6 +623,7 @@ void RE_RenderScene(const refdef_t *fd)
 
 	// the next scene rendered in this frame will tack on after this one
 	r_firstSceneDrawSurf   = tr.refdef.numDrawSurfs;
+	r_firstSceneDecal      += tr.refdef.numDecals;
 	r_firstSceneEntity     = r_numentities;
 	r_firstSceneDlight     = r_numdlights;
 	r_firstScenePoly       = r_numpolys;

--- a/src/renderer2/tr_decals.c
+++ b/src/renderer2/tr_decals.c
@@ -37,6 +37,7 @@
 #include "tr_local.h"
 
 extern int r_numDecalProjectors;
+extern int r_firstSceneDecal;
 
 typedef struct decalVert_s
 {
@@ -841,7 +842,7 @@ void R_AddDecalSurface(decal_t *decal)
 	//srfGeneric_t   *gen;
 
 	// early outs
-	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCountNoReset || tr.refdef.numDecals >= MAX_DECALS)
+	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCountNoReset || r_firstSceneDecal + tr.refdef.numDecals >= MAX_DECALS)
 	{
 		return;
 	}

--- a/src/renderer2/tr_decals.c
+++ b/src/renderer2/tr_decals.c
@@ -184,8 +184,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	// basic setup
-	temp.shader        = R_GetShaderByHandle(hShader); // debug code
-	temp.numPlanes     = temp.shader->entityMergable;
+	temp.shader        = R_GetShaderByHandle(hShader);
 	temp.color[0]      = color[0] * 255;
 	temp.color[1]      = color[1] * 255;
 	temp.color[2]      = color[2] * 255;

--- a/src/renderer2/tr_decals.c
+++ b/src/renderer2/tr_decals.c
@@ -147,12 +147,6 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	decalVert_t      dv[4];
 	decalProjector_t *dp, temp;
 
-	// first frame rendered does not have a valid decals list
-	if (tr.refdef.decalProjectors == NULL)
-	{
-		return;
-	}
-
 	if (r_numDecalProjectors >= MAX_DECAL_PROJECTORS)
 	{
 		Ren_Print("WARNING: RE_ProjectDecal() Max decal projectors reached (%d)\n", MAX_DECAL_PROJECTORS);
@@ -190,7 +184,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	temp.color[2]      = color[2] * 255;
 	temp.color[3]      = color[3] * 255;
 	temp.numPlanes     = numPoints + 2;
-	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime;
+	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime; // fixme: stale refdef time
 	temp.fadeEndTime   = temp.fadeStartTime + fadeTime;
 
 	// set up decal texcoords (fixme: support arbitrary projector st coordinates in trapcall)
@@ -298,7 +292,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	// create a new projector
-	dp = &tr.refdef.decalProjectors[r_numDecalProjectors];
+	dp = &backEndData->decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
 
 	// we have a winner

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -1485,6 +1485,7 @@ typedef struct decalProjector_s
 	int numPlanes;              // either 5 or 6, for quad or triangle projectors
 	vec4_t planes[6];
 	vec4_t texMat[3][2];
+	int projectorNum;				// global identifier
 }
 decalProjector_t;
 
@@ -2085,6 +2086,8 @@ typedef struct decal_s
 	int16_t fogIndex;
 	int numVerts;
 	polyVert_t verts[MAX_DECAL_VERTS];
+	int projectorNum;
+	int frameAdded; // need to keep decal for at least one frame so we know not to reproject it in later views
 }
 decal_t;
 

--- a/src/renderer2/tr_scene.c
+++ b/src/renderer2/tr_scene.c
@@ -58,7 +58,6 @@ int r_numPolybuffers;
 int r_firstSceneDecalProjector;
 int r_numDecalProjectors;
 int r_firstSceneDecal;
-int r_numDecals;
 
 void R_InitNextFrame(void)
 {
@@ -84,7 +83,6 @@ void R_InitNextFrame(void)
 	// decals
 	r_numDecalProjectors       = 0;
 	r_firstSceneDecalProjector = 0;
-	r_numDecals                = 0;
 	r_firstSceneDecal          = 0;
 }
 
@@ -676,7 +674,7 @@ void RE_RenderScene(const refdef_t *fd)
 	tr.refdef.numDecalProjectors = r_numDecalProjectors - r_firstSceneDecalProjector;
 	tr.refdef.decalProjectors    = &backEndData->decalProjectors[r_firstSceneDecalProjector];
 
-	tr.refdef.numDecals = r_numDecals - r_firstSceneDecal;
+	tr.refdef.numDecals = 0;
 	tr.refdef.decals    = &backEndData->decals[r_firstSceneDecal];
 
 
@@ -747,6 +745,7 @@ void RE_RenderScene(const refdef_t *fd)
 	// the next scene rendered in this frame will tack on after this one
 	r_firstSceneDrawSurf    = tr.refdef.numDrawSurfs;
 	r_firstSceneInteraction = tr.refdef.numInteractions;
+	r_firstSceneDecal       += tr.refdef.numDecals;
 	r_firstSceneEntity      = r_numEntities;
 	r_firstSceneLight       = r_numLights;
 	r_firstScenePoly        = r_numPolys;

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -181,7 +181,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	/* basic setup */
-	temp.shader        = R_GetShaderByHandle(hShader); /* debug code */ temp.numPlanes = temp.shader->entityMergable;
+	temp.shader        = R_GetShaderByHandle(hShader);
 	temp.color[0]      = color[0] * 255;
 	temp.color[1]      = color[1] * 255;
 	temp.color[2]      = color[2] * 255;

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -35,6 +35,7 @@
 #include "tr_local.h"
 
 extern int r_numDecalProjectors;
+extern int r_firstSceneDecal;
 
 typedef struct decalVert_s
 {
@@ -866,7 +867,7 @@ void R_AddDecalSurface(decal_t *decal)
 	srfGeneric_t *gen;
 
 	/* early outs */
-	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCount || tr.refdef.numDecals >= MAX_DECALS)
+	if (decal->shader == NULL || decal->parent->viewCount != tr.viewCount || r_firstSceneDecal + tr.refdef.numDecals >= MAX_DECALS)
 	{
 		return;
 	}

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -139,6 +139,7 @@ RE_ProjectDecal()
 */
 void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t projection, vec4_t color, int lifeTime, int fadeTime)
 {
+	static int       totalProjectors = 0;
 	int              i;
 	float            radius, iDist;
 	vec3_t           xyz;
@@ -292,6 +293,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	/* create a new projector */
 	dp = &backEndData->decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
+	dp->projectorNum = totalProjectors++;
 
 	/* we have a winner */
 	r_numDecalProjectors++;
@@ -380,6 +382,7 @@ void R_TransformDecalProjector(decalProjector_t *in, vec3_t axis[3], vec3_t orig
 	out->fadeEndTime      = in->fadeEndTime;
 	out->omnidirectional  = in->omnidirectional;
 	out->numPlanes        = in->numPlanes;
+	out->projectorNum     = in->projectorNum;
 
 	/* translate bounding box and sphere (note: rotated projector bounding box will be invalid!) */
 	VectorSubtract(in->mins, origin, out->mins);
@@ -647,7 +650,7 @@ static void ProjectDecalOntoWinding(decalProjector_t *dp, int numPoints, vec3_t 
 	for (i = 0; i < count; i++, decal++)
 	{
 		/* try to find an empty decal slot */
-		if (decal->shader == NULL)
+		if (decal->shader == NULL && decal->frameAdded != tr.frameCount)
 		{
 			break;
 		}
@@ -674,6 +677,8 @@ static void ProjectDecalOntoWinding(decalProjector_t *dp, int numPoints, vec3_t 
 	decal->fadeStartTime = dp->fadeStartTime;
 	decal->fadeEndTime   = dp->fadeEndTime;
 	decal->fogIndex      = surf->fogIndex;
+	decal->projectorNum  = dp->projectorNum;
+	decal->frameAdded    = tr.frameCount;
 
 	/* add points */
 	decal->numVerts = numPoints;
@@ -784,6 +789,8 @@ void R_ProjectDecalOntoSurface(decalProjector_t *dp, msurface_t *surf, bmodel_t 
 {
 	float        d;
 	srfGeneric_t *gen;
+	int          i, count;
+	decal_t      *decal;
 
 	/* early outs */
 	if (dp->shader == NULL)
@@ -795,6 +802,15 @@ void R_ProjectDecalOntoSurface(decalProjector_t *dp, msurface_t *surf, bmodel_t 
 	if ((surf->shader->surfaceFlags & (SURF_NOIMPACT | SURF_NOMARKS)) || (surf->shader->contentFlags & CONTENTS_FOG))
 	{
 		return;
+	}
+
+	/* check if this projector already has a decal on this surface */
+	count = (bmodel == tr.world->bmodels ? MAX_WORLD_DECALS : MAX_ENTITY_DECALS);
+	decal = bmodel->decals;
+	for ( i = 0; i < count; i++, decal++ ) {
+		if ( decal->parent == surf && decal->projectorNum == dp->projectorNum ) {
+			return;
+		}
 	}
 
 	/* add to counts */
@@ -944,7 +960,7 @@ R_CullDecalProjectors()
 void R_CullDecalProjectors(void)
 {
 	int              i, numDecalProjectors, decalBits;
-	decalProjector_t *dp;
+	decalProjector_t *dp, temp;
 
 	/* walk decal projector list */
 	numDecalProjectors = 0;
@@ -952,25 +968,24 @@ void R_CullDecalProjectors(void)
 	for (i = 0, dp = tr.refdef.decalProjectors; i < tr.refdef.numDecalProjectors; i++, dp++)
 	{
 		if (R_CullPointAndRadius(dp->center, dp->radius) == CULL_OUT)
+			continue;
+
+		/* put all active projectors at the beginning */
+		if (tr.refdef.numDecalProjectors > 32 && dp != &tr.refdef.decalProjectors[numDecalProjectors])
 		{
-			dp->shader = NULL;
+			/* swap them */
+			temp = tr.refdef.decalProjectors[numDecalProjectors];
+			tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+			*dp = temp;
 		}
-		else
+
+		decalBits |= (1 << numDecalProjectors);
+		numDecalProjectors++;
+
+		/* bitmask limit */
+		if (numDecalProjectors == 32)
 		{
-			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
-			{
-				/* put all active projectors at the beginning */
-				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
-			}
-
-			decalBits |= (1 << numDecalProjectors);
-			numDecalProjectors++;
-
-			/* bitmask limit */
-			if (numDecalProjectors == 32)
-			{
-				break;
-			}
+			break;
 		}
 	}
 

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -144,12 +144,6 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	decalVert_t      dv[4];
 	decalProjector_t *dp, temp;
 
-	/* first frame rendered does not have a valid decals list */
-	if (tr.refdef.decalProjectors == NULL)
-	{
-		return;
-	}
-
 	if (r_numDecalProjectors >= MAX_DECAL_PROJECTORS)
 	{
 		ri.Printf(PRINT_WARNING, "WARNING: RE_ProjectDecal() Max decal projectors reached (%d)\n", MAX_DECAL_PROJECTORS);
@@ -187,7 +181,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	temp.color[2]      = color[2] * 255;
 	temp.color[3]      = color[3] * 255;
 	temp.numPlanes     = numPoints + 2;
-	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime;
+	temp.fadeStartTime = tr.refdef.time + lifeTime - fadeTime; /* fixme: stale refdef time */
 	temp.fadeEndTime   = temp.fadeStartTime + fadeTime;
 
 	/* set up decal texcoords (fixme: support arbitrary projector st coordinates in trapcall) */
@@ -295,7 +289,7 @@ void RE_ProjectDecal(qhandle_t hShader, int numPoints, vec3_t *points, vec4_t pr
 	}
 
 	/* create a new projector */
-	dp = &tr.refdef.decalProjectors[r_numDecalProjectors];
+	dp = &backEndData->decalProjectors[r_numDecalProjectors];
 	Com_Memcpy(dp, &temp, sizeof(*dp));
 
 	/* we have a winner */

--- a/src/rendererGLES/tr_local.h
+++ b/src/rendererGLES/tr_local.h
@@ -470,6 +470,7 @@ typedef struct decalProjector_s
 	int numPlanes;                  // either 5 or 6, for quad or triangle projectors
 	vec4_t planes[6];
 	vec4_t texMat[3][2];
+	int projectorNum;				// global identifier
 }
 decalProjector_t;
 
@@ -874,6 +875,8 @@ typedef struct decal_s
 	int fogIndex;
 	int numVerts;
 	polyVert_t verts[MAX_DECAL_VERTS];
+	int projectorNum;
+	int frameAdded; // need to keep decal for at least one frame so we know not to reproject it in later views
 }
 decal_t;
 

--- a/src/rendererGLES/tr_scene.c
+++ b/src/rendererGLES/tr_scene.c
@@ -57,7 +57,6 @@ int r_numpolybuffers;
 int r_firstSceneDecalProjector;
 int r_numDecalProjectors;
 int r_firstSceneDecal;
-int r_numDecals;
 
 int skyboxportal;
 
@@ -88,7 +87,6 @@ void R_InitNextFrame(void)
 	// decals
 	r_numDecalProjectors       = 0;
 	r_firstSceneDecalProjector = 0;
-	r_numDecals                = 0;
 	r_firstSceneDecal          = 0;
 }
 
@@ -588,7 +586,7 @@ void RE_RenderScene(const refdef_t *fd)
 	tr.refdef.numDecalProjectors = r_numDecalProjectors - r_firstSceneDecalProjector;
 	tr.refdef.decalProjectors    = &backEndData->decalProjectors[r_firstSceneDecalProjector];
 
-	tr.refdef.numDecals = r_numDecals - r_firstSceneDecal;
+	tr.refdef.numDecals = 0;
 	tr.refdef.decals    = &backEndData->decals[r_firstSceneDecal];
 
 	// a single frame may have multiple scenes draw inside it --
@@ -624,6 +622,7 @@ void RE_RenderScene(const refdef_t *fd)
 
 	// the next scene rendered in this frame will tack on after this one
 	r_firstSceneDrawSurf   = tr.refdef.numDrawSurfs;
+	r_firstSceneDecal      += tr.refdef.numDecals;
 	r_firstSceneEntity     = r_numentities;
 	r_firstSceneDlight     = r_numdlights;
 	r_firstScenePoly       = r_numpolys;


### PR DESCRIPTION
Before decals where only projected in the first world scene of the frame and rendering multiple world scenes would replace decal draw surfaces from earlier scenes (causing decals to disappear in earlier scenes).

Now decals are projected in all world scenes and don't affect earlier scenes. All decal projectors added this frame when a scene is rendered will be used (including onces before the previous scene). So an explosion not visible in the first scene can be projected in later scenes. This seems to fit with how the trap_R_ProjectDecal system call is used.

Tested using a quad viewport patch I made: http://slexy.org/view/s2E96BAuzg
I haven't tested etpro multiview, gles, or r2.
