### PR TITLE
Fix scrolling inconsistency with server info

### DIFF
--- a/etmain/ui/playonline_serverinfo.menu
+++ b/etmain/ui/playonline_serverinfo.menu
@@ -70,6 +70,7 @@ menuDef {
 							90	40	10
 							135	40	30
 		visible			1
+		notselectable	1
 	}
 
 	BUTTON( (SUBWINDOW_X)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .33*((SUBWINDOW_WIDTH)-24), 18, "BACK", .3, 14, close playonline_serverinfo ; open playonline )


### PR DESCRIPTION
http://dev.etlegacy.com/issues/569

Server info was set as selectable, causing it to only scroll once you've
"scrolled" through every row of data visible in the window.
