### PR TITLE
client: fix scrolling inconsistency with server info, #fixes 569

### DIFF
--- a/etmain/ui/playonline_serverinfo.menu
+++ b/etmain/ui/playonline_serverinfo.menu
@@ -70,7 +70,7 @@ menuDef {
 							90	40	10
 							135	40	30
 		visible			1
-		notselectable	1
+		notselectable
 	}
 
 	BUTTON( (SUBWINDOW_X)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .33*((SUBWINDOW_WIDTH)-24), 18, "BACK", .3, 14, close playonline_serverinfo ; open playonline )


### PR DESCRIPTION
Removed unnecessary property value for the "notselectable" property,
which was causing the interpreter to throw an error.
