### PR TITLE
cgame: fix a typo

### DIFF
--- a/src/cgame/cg_sound.c
+++ b/src/cgame/cg_sound.c
@@ -305,7 +305,7 @@ static void CG_SoundParseSounds(char *filename, char *buffer)
 			// grab a free scriptSound
 			scriptSound = &soundScriptSounds[numSoundScriptSounds++];
 
-			if (numSoundScripts >= MAX_SOUND_SCRIPT_SOUNDS)
+			if (numSoundScriptSounds >= MAX_SOUND_SCRIPT_SOUNDS)
 			{
 				CG_Error(S_COLOR_RED "CG_SoundParseSounds: MAX_SOUND_SCRIPT_SOUNDS exceeded.\nReduce number of sound scripts.\n");
 			}


### PR DESCRIPTION
I think there is a little typo in cg_sound.c, here is the fixed version. Please note I wasn't able to test it as my etlegacy build fails in some bundled lib.
