### PR TITLE
cgame: fix for alphabetical quick menu mode

### DIFF
--- a/src/cgame/cg_fireteams.c
+++ b/src/cgame/cg_fireteams.c
@@ -419,6 +419,8 @@ const char *ftLeaderMenuListAlphachars[] =
 	"I",
 	"K",
 	"W",
+	"P",
+	"A",
 	NULL,
 };
 


### PR DESCRIPTION
Fixes the "null" in fireteam admin panel.

-*S
