### PR TITLE
Remove obsolete code from SDL_Init calls

### DIFF
--- a/src/sdl/sdl_defs.h
+++ b/src/sdl/sdl_defs.h
@@ -51,11 +51,4 @@
 #include <SDL2/SDL_cpuinfo.h>
 #endif
 
-//If we are running a debug build with MSVC we need to enable NOPARACHUTE on inits
-#if defined(_WIN32) && defined(_DEBUG) && defined(_MSC_VER)
-#define LegacySDL_Init(x) SDL_Init(x | SDL_INIT_NOPARACHUTE)
-#else
-#define LegacySDL_Init(x) SDL_Init(x)
-#endif
-
 #endif // #ifndef INCLUDE_SDLDEF_H

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -983,7 +983,7 @@ static qboolean GLimp_StartDriverAndSetMode(int mode, qboolean fullscreen, qbool
 	{
 		const char *driverName;
 
-		if (LegacySDL_Init(SDL_INIT_VIDEO) == -1)
+		if (SDL_Init(SDL_INIT_VIDEO) < 0)
 		{
 			Ren_Print("SDL_Init( SDL_INIT_VIDEO ) FAILED (%s)\n", SDL_GetError());
 			return qfalse;

--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -687,7 +687,7 @@ static void IN_InitJoystick(void)
 	if (!SDL_WasInit(SDL_INIT_JOYSTICK))
 	{
 		Com_Printf("Initializing joystick devices\n");
-		if (SDL_Init(SDL_INIT_JOYSTICK) == -1)
+		if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
 		{
 			Com_Printf("SDL_Init(SDL_INIT_JOYSTICK) failed: %s\n", SDL_GetError());
 			return;

--- a/src/sdl/sdl_snd.c
+++ b/src/sdl/sdl_snd.c
@@ -185,7 +185,7 @@ qboolean SNDDMA_Init(void)
 
 	if (!SDL_WasInit(SDL_INIT_AUDIO))
 	{
-		if (LegacySDL_Init(SDL_INIT_AUDIO) == -1)
+		if (SDL_Init(SDL_INIT_AUDIO) < 0)
 		{
 			Com_Printf("FAILED (%s)\n", SDL_GetError());
 			return qfalse;


### PR DESCRIPTION
- As per API documentation, the SDL_Init flag SDL_INIT_NOPARACHUTE is
  ignored. It is a compatibility flag for SDL1, which used it.
  Removing it from our code makes the code cleaner, especially
  removing the precompiler ifdefs.
  https://wiki.libsdl.org/SDL_Init
- The API for SDL_Init changed with SDL2. The return code is more generic
  now; error return codes may be different from -1.
