### PR TITLE
cgame: Fixes the weapon names for FG 42, MG 42 and MP 40

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -356,7 +356,7 @@ static void CG_Obituary(entityState_t *ent)
 			break;
 		case MOD_MP40:
 			message  = "was killed by";
-			message2 = "'s MP40";
+			message2 = "'s MP 40";
 			break;
 		case MOD_THOMPSON:
 			message  = "was killed by";
@@ -402,7 +402,7 @@ static void CG_Obituary(entityState_t *ent)
 			break;
 		case MOD_MG42:
 			message  = "was perforated by";
-			message2 = "'s tank-mounted MG42";
+			message2 = "'s tank-mounted MG 42";
 			break;
 		case MOD_AIRSTRIKE:
 			message  = "was blasted by";
@@ -445,7 +445,7 @@ static void CG_Obituary(entityState_t *ent)
 			break;
 		case MOD_MOBILE_MG42:
 			message  = "was mown down by";
-			message2 = "'s Mobile MG42";
+			message2 = "'s Mobile MG 42";
 			break;
 		case MOD_MOBILE_BROWNING:
 			message  = "was mown down by";
@@ -461,11 +461,11 @@ static void CG_Obituary(entityState_t *ent)
 			break;
 		case MOD_FG42:
 			message  = "was killed by";
-			message2 = "'s FG42";
+			message2 = "'s FG 42";
 			break;
 		case MOD_FG42SCOPE:
 			message  = "was sniped by";
-			message2 = "'s FG42";
+			message2 = "'s FG 42";
 			break;
 		case MOD_SATCHEL:
 			message  = "was blasted by";

--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -4141,10 +4141,10 @@ const weap_ws_t aWeaponInfo[WS_MAX] =
 	{ qfalse, "KNKB", "Ka-Bar"     },  // 1  WS_KNIFE_KBAR
 	{ qtrue,  "LUGR", "Luger"      },  // 2  WS_LUGER
 	{ qtrue,  "COLT", "Colt"       },  // 3  WS_COLT
-	{ qtrue,  "MP40", "MP-40"      },  // 4  WS_MP40
+	{ qtrue,  "MP40", "MP 40"      },  // 4  WS_MP40
 	{ qtrue,  "TMPS", "Thompson"   },  // 5  WS_THOMPSON
 	{ qtrue,  "STEN", "Sten"       },  // 6  WS_STEN
-	{ qtrue,  "FG42", "FG-42"      },  // 7  WS_FG42
+	{ qtrue,  "FG42", "FG 42"      },  // 7  WS_FG42
 	{ qtrue,  "PNZR", "Panzer"     },  // 8  WS_PANZERFAUST
 	{ qtrue,  "BZKA", "Bazooka"    },  // 9  WS_BAZOOKA
 	{ qtrue,  "FLAM", "F.Thrower"  },  // 10 WS_FLAMETHROWER
@@ -4157,7 +4157,7 @@ const weap_ws_t aWeaponInfo[WS_MAX] =
 	{ qfalse, "STCH", "Satchel"    },  // 17 WS_SATCHEL
 	{ qfalse, "GRLN", "G.Launchr"  },  // 18 WS_GRENADELAUNCHER
 	{ qfalse, "LNMN", "Landmine"   },  // 19 WS_LANDMINE
-	{ qtrue,  "MG42", "MG-42 Gun"  },  // 20 WS_MG42
+	{ qtrue,  "MG42", "MG 42 Gun"  },  // 20 WS_MG42
 	{ qtrue,  "BRNG", "Browning"   },  // 21 WS_BROWNING
 	{ qtrue,  "GARN", "Garand"     },  // 22 WS_CARBINE
 	{ qtrue,  "K-43", "K43 Rifle"  },  // 23 WS_KAR98


### PR DESCRIPTION
game: Fixes weapon names for FG 42, MG 42 and MP 40 in topshots and player stats
