### PR TITLE
cgame: fixed MG reload animation, fixes #784

### DIFF
--- a/etmain/models/multiplayer/mg42/weapon.cfg
+++ b/etmain/models/multiplayer/mg42/weapon.cfg
@@ -1,0 +1,37 @@
+///////////////////////
+//
+//		MG42
+//
+///////////////////////
+
+newfmt
+// config file for weapon animations
+
+
+//                                             	 barrel                     	 barrel
+//    first     length      fps      looping  	anim bits      animated weap   	draw bits
+//     /      ___/          /         /          /               /                  /
+//    /      /       ______/         /          /               /              	   /
+//   /      /       /       ________/          /               /              	  /
+//  /      /   	   /   	   /  	   ___________/               /              	 /
+// /   	  /   	  /   	  /   	  /   	  ___________________/              	/
+///   	 /   	 /   	 /   	 /   	 /   	 ______________________________/
+//   	/   	/   	/   	/   	/   	/
+
+0	1	20	1	0	0	0	// IDLE1
+134	1	20	1	0	0	0 	// IDLE2			// idle in prone
+
+1	8	20	8	0	0	0	// ATTACK1
+158	3	20	3	0	0	0       // ATTACK2			// attack in prone
+9	10	20	0	0	0	0	// WEAP_ATTACK_LASTSHOT
+
+19	11	40	0	0	0	0	// DROP
+30	25	45	0	0	0	0	// RAISE
+53	36	14	1	0	0	0	// RELOAD1
+186	30	24	0	0	0	0	// RELOAD2			// unset and drop
+160	27	9	0	0	0	0	// RELOAD3			// reload in prone
+
+186	19	18	0	0	0	0	// WEAP_ALTSWITCHFROM		// unset bipod
+111	20	18	0	0	0	0	// WEAP_ALTSWITCHTO		// set bipod
+103	31	18	0	0	0	0	// WEAP_DROP2			// raise and set
+


### PR DESCRIPTION
Fixed values for the MG42 weapon.cfg fixes both MG and Browning's reload animations.

-*S
