### PR TITLE
OS X: Searches for resources in bundle resource directory

### DIFF
--- a/src/sys/SDLMain.m
+++ b/src/sys/SDLMain.m
@@ -231,9 +231,13 @@ static void CustomApplicationMain( int argc, char **argv )
 }
 
 /* Set the working directory to the .app's parent directory */
-- (void) setupWorkingDirectory
+- (void) setupWorkingDirectory:(BOOL)shouldChdir
 {
-	
+	if (shouldChdir)
+	{
+		NSString *path = [[NSBundle mainBundle] resourcePath];
+		[[NSFileManager defaultManager] changeCurrentDirectoryPath:path];
+	}
 }
 
 void Cbuf_AddText( const char *text );
@@ -260,7 +264,8 @@ void Cbuf_AddText( const char *text );
 {
 	int status;
 
-	
+	/* Set the working directory to the .app's parent directory */
+	[self setupWorkingDirectory:gFinderLaunch];
 
 	/* Hand off to main application code */
 	gCalledAppMainline = TRUE;
@@ -278,17 +283,7 @@ void Cbuf_AddText( const char *text );
 /* Main entry point to executable - should *not* be SDL_main! */
 int main ( int argc, char **argv )
 {
-	/* Set the working directory to the .app's parent directory */
-	char parentdir[MAXPATHLEN];
-	CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
-	CFURLRef url2 = CFURLCreateCopyDeletingLastPathComponent(0, url);
-	if (CFURLGetFileSystemRepresentation(url2, 1, (UInt8 *)parentdir, MAXPATHLEN)) {
-		chdir(parentdir);   /* chdir to the binary app's parent */
-	}
-	CFRelease(url);
-	CFRelease(url2);
-	
-	
+
 	/* Copy the arguments into a global variable */
 	/* This is passed if we are launched by double-clicking */
 	if ( argc >= 2 && strncmp( argv[ 1 ], "-psn", 4 ) == 0 )

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1029,8 +1029,9 @@ int main(int argc, char **argv)
 	// But on OS X we want to pretend the binary path is the .app's parent
 	// So that way the base folder is right next to the .app allowing
 	{
-		char     parentdir[1024];
-		CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+
+		char     resourcedir[1024];
+		CFURLRef url = CFBundleCopyResourceURL(CFBundleGetMainBundle(), CFSTR("etl"), CFSTR("icns"), NULL);
 		if (!url)
 		{
 			Sys_Dialog(DT_ERROR, "A CFURL for the app bundle could not be found.", "Can't set Sys_SetBinaryPath");
@@ -1038,16 +1039,18 @@ int main(int argc, char **argv)
 		}
 
 		CFURLRef url2 = CFURLCreateCopyDeletingLastPathComponent(0, url);
-		if (!url2 || !CFURLGetFileSystemRepresentation(url2, 1, (UInt8 *)parentdir, 1024))
+		if (!url2 || !CFURLGetFileSystemRepresentation(url2, 1, (UInt8 *)resourcedir, 1024))
 		{
-			Sys_Dialog(DT_ERROR, "CFURLGetFileSystemRepresentation returned an error when finding the app bundle's parent directory.", "Can't set Sys_SetBinaryPath");
+			Sys_Dialog(DT_ERROR, "CFURLGetFileSystemRepresentation returned an error when finding the app resources directory.", "Can't set Sys_SetBinaryPath");
 			Sys_Exit(1);
 		}
 
-		Sys_SetBinaryPath(parentdir);
+		// At this point were really actually setting the path to Resources
+		Sys_SetBinaryPath(resourcedir);
 
 		CFRelease(url);
 		CFRelease(url2);
+
 	}
 #else
 	Sys_SetBinaryPath(Sys_Dirname(argv[0]));


### PR DESCRIPTION
I got tired of maintaining all the data files outside (along side) the main application.

Given that OS X has the structure for bundling all related files together in `.app` I figured why not leverage that.

This allows for all resources (`etmain/` and `legacy/`) to be bundled inside the `Contents/Resources` directory.

Makes for a nice contained `ET Legacy.app` OS X application.

The only small caveat is that one will need to replace (or remove entirely, I tested that and it works) the `~/Library/etlegacy/legacy/ui_mac` file.

Enjoy :)
