### PR TITLE
cgame: MG & Browning reload anytime, refs #716

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,7 @@
 	path = libs
 	url = git://github.com/etlegacy/etlegacy-libs.git
 	branch = master
+	ignore = dirty
 [submodule "scripts"]
 	path = scripts
 	url = git://github.com/etlegacy/etlegacy-lua_scripts.git

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2377,10 +2377,12 @@ static void PM_BeginWeaponReload(int weapon)
 		break;
 	case WP_MOBILE_BROWNING:
 	case WP_MOBILE_BROWNING_SET:
+		/*
 		if (pm->ps->ammoclip[WP_MOBILE_BROWNING] != 0)
 		{
 			return;
 		}
+		*/
 		break;
 
 	// if ((weapon <= WP_NONE || weapon > WP_DYNAMITE) && !(weapon >= WP_KAR98 && weapon < WP_NUM_WEAPONS))

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2368,10 +2368,12 @@ static void PM_BeginWeaponReload(int weapon)
 	{
 	case WP_MOBILE_MG42:
 	case WP_MOBILE_MG42_SET:
+		/*
 		if (pm->ps->ammoclip[WP_MOBILE_MG42] != 0)
 		{
 			return;
 		}
+		*/
 		break;
 	case WP_MOBILE_BROWNING:
 	case WP_MOBILE_BROWNING_SET:


### PR DESCRIPTION
Feature task #716: Commenting out the MOBILE_MG42 & Browning cases makes it possible to reload MG/Browning at any time. I commented it out because I wasn't sure if this feature was permitted. Removing both MG and Browning cases applies this feature.
