### PR TITLE
ui: Added possibility to unbind key in controls menu, ref #761

### DIFF
--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -642,6 +642,7 @@ extern qboolean UI_CursorInRect(int x, int y, int width, int height);
 // ui_shared.c
 int Binding_IDFromName(const char *name);
 void Binding_Set(int id, int b1, int b2);
+void Binding_Unset(int id, int index);
 qboolean Binding_Check(int id, qboolean b1, int key);
 int Binding_Get(int id, qboolean b1);
 int Binding_Count(void);

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -773,13 +773,44 @@ void Binding_Set(int id, int b1, int b2)
 	{
 		if (b1 != -2)
 		{
+			int key1;
+			int key2;
+
+			// Set the current value of bind1 to bind2
+			DC->getKeysForBinding(g_bindings[id].command, &key1, &key2);
+			Binding_Set(id, -2, key1);
+
+			Binding_Unset(id, 1);
 			g_bindings[id].bind1 = b1;
 		}
 
 		if (b2 != -2)
 		{
+			Binding_Unset(id, 2);
 			g_bindings[id].bind2 = b2;
 		}
+	}
+}
+
+void Binding_Unset(int id, int index)
+{
+	int key1;
+	int key2;
+
+	// Find the keys binded to action
+	DC->getKeysForBinding(g_bindings[id].command, &key1, &key2);
+
+	// Unbind the key1 or key2 according to index
+	switch (index)
+	{
+	case 1:
+		DC->setBinding(key1, "");
+		break;
+	case 2:
+		DC->setBinding(key2, "");
+		break;
+	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
I added a possibility to unbind key by pressing backspace in the controls menu. I don't know if this is considered as a bug but if both of the bindings are assigned and you try to assign new value, there will only the new key binded to action. What I'm trying to say is that there will be no bind2 assigned after assigning new value in the situation where both bind1 and bind2 are assigned. I don't think it's a bug but I wanna be sure.
