### PR TITLE
game: Fixes weapon cycle bug, fixes #562

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3794,6 +3794,7 @@ static void PM_Weapon(void)
 	{
 		if (pm->ps->weapon != pm->cmd.weapon)
 		{
+			pm->ps->weaponTime = 0;
 			PM_BeginWeaponChange(pm->ps->weapon, pm->cmd.weapon, qfalse);
 		}
 	}


### PR DESCRIPTION
By zeroing the weapon time there, fixes the delay issue occuring while trying to switch the weapon from MG when standing up. There was a same kinda issue with mortar but it wasn't that noticeable because the switchtime is smaller than with MG. There was also an issue where panzerfaust simply flashes quickly after shooting if you try to change the weapon at the same time. By setting weaponTime = 0, this issue also is fixed.

There might be some side effects but at least I couldn't produce any...

Another option to fix this problem is to decrease the MG switchtime. What this also does, it makes a player able to shoot earlier after standing up. Right now there is a little delay between standing up and shooting after that.
