### PR TITLE
renderers: Fix MDS/MDM indexes for GLES

### DIFF
--- a/src/renderer/tr_animation_mdm.c
+++ b/src/renderer/tr_animation_mdm.c
@@ -55,8 +55,9 @@ frame.
 static float                    frontlerp, backlerp;
 static float                    torsoFrontlerp, torsoBacklerp;
 static int                      *triangles, *boneRefs;
-static glIndex_t                indexes, *pIndexes;
-static glIndex_t                baseIndex, baseVertex, oldIndexes;
+static int                      indexes;
+static glIndex_t                *pIndexes;
+static int                      baseIndex, baseVertex, oldIndexes;
 static int                      numVerts;
 static mdmVertex_t              *v;
 static mdxBoneFrame_t           bones[MDX_MAX_BONES], rawBones[MDX_MAX_BONES], oldBones[MDX_MAX_BONES];
@@ -1598,15 +1599,8 @@ void RB_MDM_SurfaceAnim(mdmSurface_t *surface)
 
 	if (render_count == surface->numVerts)
 	{
-		memcpy(pIndexes, triangles, sizeof(triangles[0]) * indexes);
-		if (baseVertex)
-		{
-			glIndex_t *indexesEnd;
-
-			for (indexesEnd = pIndexes + indexes ; pIndexes < indexesEnd ; pIndexes++)
-			{
-				*pIndexes += baseVertex;
-			}
+		for ( j = 0; j < indexes; j++ ) {
+			pIndexes[j] = triangles[j] + baseVertex;
 		}
 		tess.numIndexes += indexes;
 	}

--- a/src/renderer/tr_animation_mds.c
+++ b/src/renderer/tr_animation_mds.c
@@ -53,8 +53,9 @@ frame.
 static float                    frontlerp, backlerp;
 static float                    torsoFrontlerp, torsoBacklerp;
 static int                      *triangles, *boneRefs;
-static glIndex_t                indexes, *pIndexes;
-static glIndex_t                baseIndex, baseVertex, oldIndexes;
+static int                      indexes;
+static glIndex_t                *pIndexes;
+static int                      baseIndex, baseVertex, oldIndexes;
 static int                      numVerts;
 static mdsVertex_t              *v;
 static mdsBoneFrame_t           bones[MDS_MAX_BONES], rawBones[MDS_MAX_BONES], oldBones[MDS_MAX_BONES];
@@ -1360,12 +1361,15 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 		render_count = surface->numVerts;
 	}
 
-	RB_CheckOverflow(render_count, surface->numTriangles);
+	RB_CheckOverflow(render_count, surface->numTriangles * 3);
 
 //DBG_SHOWTIME
 
+	//
 	// setup triangle list
-	RB_CheckOverflow(surface->numVerts, surface->numTriangles * 3);
+	//
+	// no need to do this twice
+	//% RB_CheckOverflow(surface->numVerts, surface->numTriangles * 3);
 
 //DBG_SHOWTIME
 
@@ -1384,14 +1388,8 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 
 	if (render_count == surface->numVerts)
 	{
-		memcpy(pIndexes, triangles, sizeof(triangles[0]) * indexes);
-		if (baseVertex)
-		{
-			glIndex_t *indexesEnd;
-			for (indexesEnd = pIndexes + indexes ; pIndexes < indexesEnd ; pIndexes++)
-			{
-				*pIndexes += baseVertex;
-			}
+		for ( j = 0; j < indexes; j++ ) {
+			pIndexes[j] = triangles[j] + baseVertex;
 		}
 		tess.numIndexes += indexes;
 	}

--- a/src/rendererGLES/tr_animation_mdm.c
+++ b/src/rendererGLES/tr_animation_mdm.c
@@ -55,8 +55,9 @@ frame.
 static float                    frontlerp, backlerp;
 static float                    torsoFrontlerp, torsoBacklerp;
 static int                      *triangles, *boneRefs;
-static glIndex_t                indexes, *pIndexes;
-static glIndex_t                baseIndex, baseVertex, oldIndexes;
+static int                      indexes;
+static glIndex_t                *pIndexes;
+static int                      baseIndex, baseVertex, oldIndexes;
 static int                      numVerts;
 static mdmVertex_t              *v;
 static mdxBoneFrame_t           bones[MDX_MAX_BONES], rawBones[MDX_MAX_BONES], oldBones[MDX_MAX_BONES];
@@ -1598,15 +1599,8 @@ void RB_MDM_SurfaceAnim(mdmSurface_t *surface)
 
 	if (render_count == surface->numVerts)
 	{
-		memcpy(pIndexes, triangles, sizeof(triangles[0]) * indexes);
-		if (baseVertex)
-		{
-			glIndex_t *indexesEnd;
-
-			for (indexesEnd = pIndexes + indexes ; pIndexes < indexesEnd ; pIndexes++)
-			{
-				*pIndexes += baseVertex;
-			}
+		for ( j = 0; j < indexes; j++ ) {
+			pIndexes[j] = triangles[j] + baseVertex;
 		}
 		tess.numIndexes += indexes;
 	}

--- a/src/rendererGLES/tr_animation_mds.c
+++ b/src/rendererGLES/tr_animation_mds.c
@@ -53,8 +53,9 @@ frame.
 static float                    frontlerp, backlerp;
 static float                    torsoFrontlerp, torsoBacklerp;
 static int                      *triangles, *boneRefs;
-static glIndex_t                indexes, *pIndexes;
-static glIndex_t                baseIndex, baseVertex, oldIndexes;
+static int                      indexes;
+static glIndex_t                *pIndexes;
+static int                      baseIndex, baseVertex, oldIndexes;
 static int                      numVerts;
 static mdsVertex_t              *v;
 static mdsBoneFrame_t           bones[MDS_MAX_BONES], rawBones[MDS_MAX_BONES], oldBones[MDS_MAX_BONES];
@@ -1360,12 +1361,15 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 		render_count = surface->numVerts;
 	}
 
-	RB_CheckOverflow(render_count, surface->numTriangles);
+	RB_CheckOverflow(render_count, surface->numTriangles * 3);
 
 //DBG_SHOWTIME
 
+	//
 	// setup triangle list
-	RB_CheckOverflow(surface->numVerts, surface->numTriangles * 3);
+	//
+	// no need to do this twice
+	//% RB_CheckOverflow(surface->numVerts, surface->numTriangles * 3);
 
 //DBG_SHOWTIME
 
@@ -1384,14 +1388,8 @@ void RB_SurfaceAnim(mdsSurface_t *surface)
 
 	if (render_count == surface->numVerts)
 	{
-		memcpy(pIndexes, triangles, sizeof(triangles[0]) * indexes);
-		if (baseVertex)
-		{
-			glIndex_t *indexesEnd;
-			for (indexesEnd = pIndexes + indexes ; pIndexes < indexesEnd ; pIndexes++)
-			{
-				*pIndexes += baseVertex;
-			}
+		for ( j = 0; j < indexes; j++ ) {
+			pIndexes[j] = triangles[j] + baseVertex;
 		}
 		tess.numIndexes += indexes;
 	}


### PR DESCRIPTION
GLES glIndex_t is a short instead of int, cannot memcpy int to short array.

Based on a [iortcw commit](https://github.com/iortcw/iortcw/commit/ec3318172a827f75c60940ed1a798273db5db72b) by SmileTheory.

Also, change some variables that do not need to be glIndex_t back to int. And fix MDS RB_CheckOverflow.
