### PR TITLE
renderers: Don't show incompatible font warning if file does not exist

### DIFF
--- a/src/renderercommon/tr_font.c
+++ b/src/renderercommon/tr_font.c
@@ -426,7 +426,7 @@ qboolean R_LoadPreRenderedFont(const char *datName, fontInfo_t *font)
 		ri.FS_FreeFile(faceData);
 		return qtrue;
 	}
-	else
+	else if (len != -1)
 	{
 		Ren_Warning("R_LoadPreRenderedFont: font file %s is in an incompatible format.\n", datName);
 	}


### PR DESCRIPTION
If pre-rendered font does not exist, FS_ReadFile returns -1. Let's not say the font is incompatible.
