### PR TITLE
renderers: Say what the missing pre-renderer font's filename is

### DIFF
--- a/src/renderercommon/tr_font.c
+++ b/src/renderercommon/tr_font.c
@@ -426,9 +426,13 @@ qboolean R_LoadPreRenderedFont(const char *datName, fontInfo_t *font)
 		ri.FS_FreeFile(faceData);
 		return qtrue;
 	}
-	else if (len != -1)
+	else if (len == -1)
 	{
-		Ren_Warning("R_LoadPreRenderedFont: font file %s is in an incompatible format.\n", datName);
+		Ren_Warning("R_LoadPreRenderedFont: font file '%s' was not found.\n", datName);
+	}
+	else
+	{
+		Ren_Warning("R_LoadPreRenderedFont: font file '%s' is in an incompatible format.\n", datName);
 	}
 
 	return qfalse;
@@ -705,8 +709,6 @@ static qboolean R_GetFont(const char *fontName, int pointSize, fontInfo_t *font)
 	{
 		return qtrue;
 	}
-
-	Ren_Warning("R_GetFont: no font available.\n");
 
 	return qfalse;
 }


### PR DESCRIPTION
Before when calling trap_R_RegisterFont( "fonts/font", 18 ) like Quake 3 Team Arena:

```
R_LoadScalableFont: Unable to find any supported font files by the name of fonts/font
R_GetFont: no font available.
RE_RegisterFont: failed to register font with name 'fonts/font'
```

After patch

```
R_LoadScalableFont: Unable to find any supported font files by the name of fonts/font
R_LoadPreRenderedFont: font file 'fonts/fonts/font_18.dat' was not found.
RE_RegisterFont: failed to register font with name 'fonts/font'
```

---

The RE_RegisterFont warning seems unneeded since both font types already report failure, but typically a font will exist so it's not really a big concern.

Team Arena passed "fonts/" to RegisterFont, in ET the engine adds it; so "fonts/fonts/font_18.dat" is the correct file name to display. This is nothing ETL needs to be concerned about; Team Arena is hard coded to fonts/fontImage_#.dat anyway, which can be done in ET using "fontImage" for font name.
