### PR TITLE
Refactoring conditional directives that break parts of statements. 

### DIFF
--- a/src/client/snd_openal.c
+++ b/src/client/snd_openal.c
@@ -3043,10 +3043,11 @@ qboolean S_AL_Init(soundInterface_t *si)
 		// !!! FIXME:  extension string. We need to check the version string,
 		// !!! FIXME:  then the extension string, but that's too much trouble,
 		// !!! FIXME:  so we'll just check the function pointer for now.
-		if (qalcCaptureOpenDevice == NULL)
+		qboolean test = qalcCaptureOpenDevice == NULL;
 #else
-		if (!qalcIsExtensionPresent(NULL, "ALC_EXT_capture"))
+		qboolean test = !qalcIsExtensionPresent(NULL, "ALC_EXT_capture");
 #endif
+		if (test)
 		{
 			Com_Printf("No ALC_EXT_capture support, can't record audio.\n");
 		}

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -2719,6 +2719,7 @@ void Com_Init(char *commandLine)
 	// gcc warning: variable `safeMode' might be clobbered by `longjmp' or `vfork'
 	volatile qboolean safeMode = qtrue;
 	int               qport;
+	qboolean test;
 
 	Com_Printf(ET_VERSION "\n");
 
@@ -2810,10 +2811,11 @@ void Com_Init(char *commandLine)
 			if (!Com_CheckProfile())
 			{
 #if !defined(DEDICATED) && !defined(LEGACY_DEBUG)
-				if (Sys_Dialog(DT_YES_NO, "ET:L crashed last time it was running. Do you want to reset settings to default values?\n\nNote & Warning:\nIf you are running several client instances ensure a different value\nof CVAR fs_homepath is set for each client.\nOtherwise the same profile path is used which may cause other side effects.", "Reset settings") == DR_YES)
+				test = Sys_Dialog(DT_YES_NO, "ET:L crashed last time it was running. Do you want to reset settings to default values?\n\nNote & Warning:\nIf you are running several client instances ensure a different value\nof CVAR fs_homepath is set for each client.\nOtherwise the same profile path is used which may cause other side effects.", "Reset settings") == DR_YES;
 #else
-				if (qfalse)
+				test = qfalse;
 #endif
+				if (test)
 				{
 					Com_Printf("WARNING: profile.pid found for profile '%s' - system settings will revert to defaults\n", cl_profileStr);
 					// set crashed state


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

```
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/
```

It might improve code understanding, maintainability and error-proneness.
