### PR TITLE
math.h replaced by cmath

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -144,7 +144,7 @@ typedef int intptr_t;
 #else
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>

--- a/src/sdl/sdl_glimp.cpp
+++ b/src/sdl/sdl_glimp.cpp
@@ -37,7 +37,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 
 #include "../sys/sys_local.h"
 #include "../client/client.h"


### PR DESCRIPTION
Math functions at <cmath> accept integers as arguments.
