### PR TITLE
Fixed sndio link flag missing with bundled SDL2

### DIFF
--- a/cmake/ETLSetupFeatures.cmake
+++ b/cmake/ETLSetupFeatures.cmake
@@ -48,7 +48,7 @@ if(BUILD_CLIENT)
 		list(APPEND SDL_LIBRARIES ${SDL2_LIBRARY})
 		include_directories(SYSTEM ${SDL2_INCLUDE_DIR})
 	else() # BUNDLED_SDL
-		list(APPEND SDL_LIBRARIES ${SDL32_BUNDLED_LIBRARIES})
+		list(APPEND SDL_LIBRARIES ${SDL32_BUNDLED_LIBRARIES} sndio)
 		include_directories(SYSTEM ${SDL32_BUNDLED_INCLUDE_DIR})
 		add_definitions(-DBUNDLED_SDL)
 		add_definitions(-DHAVE_SDL) # for tinygettext


### PR DESCRIPTION
Fix for issue #972

```
Linking CXX executable etl
libs/openal/libopenal.a(sndio.c.o): In function `sndio_stop_playback':
sndio.c:(.text+0x53): undefined reference to `sio_stop'
libs/openal/libopenal.a(sndio.c.o): In function `sndio_start_playback':
sndio.c:(.text+0xc3): undefined reference to `sio_start'
sndio.c:(.text+0x142): undefined reference to `sio_stop'
libs/openal/libopenal.a(sndio.c.o): In function `sndio_proc':
sndio.c:(.text+0x228): undefined reference to `sio_write'
libs/openal/libopenal.a(sndio.c.o): In function `sndio_reset_playback':
sndio.c:(.text+0x2b2): undefined reference to `sio_initpar'
sndio.c:(.text+0x328): undefined reference to `sio_setpar'
sndio.c:(.text+0x38f): undefined reference to `sio_getpar'
libs/openal/libopenal.a(sndio.c.o): In function `sndio_close_playback':
sndio.c:(.text+0x5a2): undefined reference to `sio_close'
libs/openal/libopenal.a(sndio.c.o): In function `sndio_open_playback':
sndio.c:(.text+0x60f): undefined reference to `sio_open'
../libs/sdl2/build/.libs/libSDL2.a(SDL_sndioaudio.o): In function `load_sndio_syms':
SDL_sndioaudio.c:(.text+0x9): undefined reference to `sio_open'
SDL_sndioaudio.c:(.text+0x13): undefined reference to `sio_close'
SDL_sndioaudio.c:(.text+0x1d): undefined reference to `sio_setpar'
SDL_sndioaudio.c:(.text+0x27): undefined reference to `sio_getpar'
SDL_sndioaudio.c:(.text+0x31): undefined reference to `sio_start'
SDL_sndioaudio.c:(.text+0x3b): undefined reference to `sio_stop'
SDL_sndioaudio.c:(.text+0x45): undefined reference to `sio_read'
SDL_sndioaudio.c:(.text+0x4f): undefined reference to `sio_write'
SDL_sndioaudio.c:(.text+0x59): undefined reference to `sio_initpar'
collect2: error: ld returned 1 exit status
CMakeFiles/etl.dir/build.make:2341: recipe for target 'etl' failed
make[2]: *** [etl] Error 1
CMakeFiles/Makefile2:669: recipe for target 'CMakeFiles/etl.dir/all' failed
make[1]: *** [CMakeFiles/etl.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
```