### PR TITLE
Fix glsl shaders for loading them via fs_game

### DIFF
--- a/src/renderer2/glsl/generic_fp.glsl
+++ b/src/renderer2/glsl/generic_fp.glsl
@@ -42,9 +42,11 @@ void main()
 	color *= var_Color;
 
 	//Dushan added this. Why?
-#if 0 //defined(USE_TCGEN_ENVIRONMENT)
+//#if defined(USE_TCGEN_ENVIRONMENT)
+#if 0
 	gl_FragColor = vec4(vec3(1.0, 0.0, 0.0), color.a);
 #else
+	color[0] = 1.0;
 	gl_FragColor = color;
 #endif
 }

--- a/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
+++ b/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
@@ -83,7 +83,8 @@ void main()
 	texDiffuse.st  += texOffset;
 	texNormal.st   += texOffset;
 	texSpecular.st += texOffset;
-#endif // USE_PARALLAX_MAPPING
+#endif
+// USE_PARALLAX_MAPPING
 
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texDiffuse);
@@ -181,13 +182,15 @@ void main()
 	// gl_FragColor = vec4(vec3(var_LightColor.a, var_LightColor.a, var_LightColor.a), 1.0);
 	// gl_FragColor = var_LightColor;
 
-#if 0 //defined(r_ShowTerrainBlends)
+//defined(r_ShowTerrainBlends)
+#if 0
 	color = vec4(vec3(var_LightColor.a), 1.0);
 #endif
 
 	gl_FragColor = color;
 
-#else // USE_NORMAL_MAPPING
+#else
+// USE_NORMAL_MAPPING
 
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, var_TexDiffuseNormal.st);

--- a/src/renderer2/tr_glsl.c
+++ b/src/renderer2/tr_glsl.c
@@ -1132,7 +1132,7 @@ static int GLSL_CompileGPUShader(GLhandleARB program, GLhandleARB *prevShader, c
 		ri.FS_WriteFile(va("debug/%s_%s.debug", name, (shaderType == GL_VERTEX_SHADER ? "vertex" : "fragment")), buffer, size);
 		GLSL_PrintShaderSource(shader);
 		GLSL_PrintInfoLog(shader, qfalse, qfalse);
-		Ren_Fatal("Couldn't compile shader");
+		Ren_Fatal("Couldn't compile shader \"%s\"", name);
 		//return 0;
 	}
 


### PR DESCRIPTION
The glsl parser fails when there is an #if 0 and // in the same line.

The pregenerated shaders do not cause any problems, because the comments are stripped.