### PR TITLE
fix: utf/extended ascii symbols in commands caused unexpected behavior

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1334,7 +1334,7 @@ void CL_WritePacket(void)
 		// also use the message acknowledge
 		key ^= clc.serverMessageSequence;
 		// also use the last acknowledged server command in the key
-		key ^= Com_HashKey(clc.serverCommands[clc.serverCommandSequence & (MAX_RELIABLE_COMMANDS - 1)], 32);
+		key ^= MSG_HashKey(clc.serverCommands[clc.serverCommandSequence & (MAX_RELIABLE_COMMANDS - 1)], 32);
 
 		// write all the commands, including the predicted command
 		for (i = 0 ; i < count ; i++)

--- a/src/client/cl_net_chan.c
+++ b/src/client/cl_net_chan.c
@@ -84,7 +84,7 @@ static void CL_Netchan_Encode(msg_t *msg)
 			index = 0;
 		}
 
-		if ((IS_LEGACY_MOD && string[index] == '%') || ((byte)string[index] > 127 || string[index] == '%'))
+		if ((!IS_LEGACY_MOD && (byte)string[index] > 127) || string[index] == '%')
 		{
 			string[index] = '.';
 		}
@@ -133,7 +133,7 @@ static void CL_Netchan_Decode(msg_t *msg)
 			index = 0;
 		}
 
-		if ((IS_LEGACY_MOD && string[index] == '%') || ((byte)string[index] > 127 || string[index] == '%'))
+		if ((!IS_LEGACY_MOD && (byte)string[index] > 127) || string[index] == '%')
 		{
 			string[index] = '.';
 		}

--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -567,6 +567,21 @@ void MSG_WriteAngle16(msg_t *msg, float f)
 	MSG_WriteShort(msg, ANGLE2SHORT(f));
 }
 
+// a string hasher which gives the same hash value even if the
+// string is later modified via the legacy MSG read/write code
+int MSG_HashKey(const char *string, int maxlen) {
+	int hash, i;
+	hash = 0;
+	for (i = 0; i < maxlen && string[i] != '\0'; i++) {
+		if ((!IS_LEGACY_MOD && string[i] & 0x80) || string[i] == '%')
+			hash += '.' * (119 + i);
+		else
+			hash += string[i] * (119 + i);
+	}
+	hash = (hash ^ (hash >> 10) ^ (hash >> 20));
+	return hash;
+}
+
 //============================================================
 
 // reading functions

--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -474,7 +474,7 @@ void MSG_WriteString(msg_t *msg, const char *s)
 	}
 	else
 	{
-		int  l;
+		int  l, i;
 		char string[MAX_STRING_CHARS];
 
 		l = strlen(s);
@@ -486,17 +486,12 @@ void MSG_WriteString(msg_t *msg, const char *s)
 		}
 		Q_strncpyz(string, s, sizeof(string));
 
-		if (!IS_LEGACY_MOD)
+		// get rid of 0x80+ and '%' chars, because old clients don't like them
+		for (i = 0 ; i < l ; i++)
 		{
-			int i;
-
-			// only allow ascii and translate all '%' fmt spec to avoid crash bugs
-			for (i = 0 ; i < l ; i++)
+			if ((!IS_LEGACY_MOD && (byte)string[i] > 127) || string[i] == '%')
 			{
-				if ((byte)string[i] > 127 || string[i] == '%')
-				{
-					string[i] = '.';
-				}
+				string[i] = '.';
 			}
 		}
 
@@ -517,7 +512,7 @@ void MSG_WriteBigString(msg_t *msg, const char *s)
 	}
 	else
 	{
-		int  l;
+		int  l, i;
 		char string[BIG_INFO_STRING];
 
 		l = strlen(s);
@@ -529,17 +524,12 @@ void MSG_WriteBigString(msg_t *msg, const char *s)
 		}
 		Q_strncpyz(string, s, sizeof(string));
 
-		if (!IS_LEGACY_MOD)
+		// get rid of 0x80+ and '%' chars, because old clients don't like them
+		for (i = 0 ; i < l ; i++)
 		{
-			int i;
-
-			// only allow ascii and translate all '%' fmt spec to avoid crash bugs
-			for (i = 0 ; i < l ; i++)
+			if ((!IS_LEGACY_MOD && (byte)string[i] > 127) || string[i] == '%')
 			{
-				if ((byte)string[i] > 127 || string[i] == '%')
-				{
-					string[i] = '.';
-				}
+				string[i] = '.';
 			}
 		}
 

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -95,6 +95,7 @@ void MSG_WriteFloat(msg_t *msg, float f);
 void MSG_WriteString(msg_t *msg, const char *s);
 void MSG_WriteBigString(msg_t *msg, const char *s);
 void MSG_WriteAngle16(msg_t *msg, float f);
+int MSG_HashKey(const char *string, int maxlen);
 
 void MSG_BeginReading(msg_t *msg);
 void MSG_BeginReadingOOB(msg_t *msg);

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -1820,7 +1820,7 @@ static void SV_UserMove(client_t *cl, msg_t *msg, qboolean delta)
 	// also use the message acknowledge
 	key ^= cl->messageAcknowledge;
 	// also use the last acknowledged server command in the key
-	key ^= Com_HashKey(cl->reliableCommands[cl->reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)], 32);
+	key ^= MSG_HashKey(cl->reliableCommands[cl->reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)], 32);
 
 	memset(&nullcmd, 0, sizeof(nullcmd));
 	oldcmd = &nullcmd;

--- a/src/server/sv_net_chan.c
+++ b/src/server/sv_net_chan.c
@@ -83,8 +83,7 @@ static void SV_Netchan_Encode(client_t *client, msg_t *msg, char *commandString)
 		{
 			index = 0;
 		}
-
-		if ((IS_LEGACY_MOD && string[index] == '%') || ((byte)string[index] > 127 || string[index] == '%'))
+		if ((!IS_LEGACY_MOD && (byte)string[index] > 127) || string[index] == '%')
 		{
 			string[index] = '.';
 		}
@@ -137,7 +136,7 @@ static void SV_Netchan_Decode(client_t *client, msg_t *msg)
 			index = 0;
 		}
 
-		if ((IS_LEGACY_MOD && string[index] == '%') || ((byte)string[index] > 127 || string[index] == '%'))
+		if ((!IS_LEGACY_MOD && (byte)string[index] > 127) || string[index] == '%')
 		{
 			string[index] = '.';
 		}


### PR DESCRIPTION
This is my fix for this issue: https://dev.etlegacy.com/issues/1037 
1) it fixes problem for specifically etlegacy mod, where server/client encoder/decoder had wrong conditional statement which caused the bug
2) it fixes pretty much similar problem for other mods, where Com_HashKey function caused same effect as for legacy mod, because it used the raw command, more info here: https://bugzilla.icculus.org/show_bug.cgi?id=4060