### PR TITLE
qcommon: MSG_Read String functions fix

### DIFF
--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -697,7 +697,7 @@ char *MSG_ReadString(msg_t *msg)
 
 		// translate all '%' fmt spec to avoid crash bugs
 		// don't allow higher ascii values
-		if (c == '%' || c > 127)
+		if ((!IS_LEGACY_MOD && (c & 0x80)) || c == '%')
 		{
 			c = '.';
 		}
@@ -733,7 +733,7 @@ char *MSG_ReadBigString(msg_t *msg)
 
 		// translate all '%' fmt spec to avoid crash bugs
 		// don't allow higher ascii values
-		if (c == '%' || c > 127)
+		if ((!IS_LEGACY_MOD && (c & 0x80)) || c == '%')
 		{
 			c = '.';
 		}
@@ -769,7 +769,7 @@ char *MSG_ReadStringLine(msg_t *msg)
 
 		// translate all '%' fmt spec to avoid crash bugs
 		// don't allow higher ascii values
-		if (c == '%' || c > 127)
+		if ((!IS_LEGACY_MOD && (c & 0x80)) || c == '%')
 		{
 			c = '.';
 		}


### PR DESCRIPTION
The latest [msg_readstring functions ioq3 patch](https://github.com/isRyven/etlegacy/commit/e29ea3d56953b62756573b4b42702b10f0a03d24)  caused user to be disconnected if you enter extended ascii symbols on legacy mod exclusively, my little patch to fix that.