### PR TITLE
general: fix key code API compatibility and add right alt key

### DIFF
--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -341,7 +341,7 @@ void CG_DemoClick(int key, qboolean down)
 	if (cg.demohelpWindow == SHOW_ON)
 	{
 		// pull up extended helpmenu
-		if (cgs.currentMenuLevel == ML_MAIN && key == K_ALT)
+		if (cgs.currentMenuLevel == ML_MAIN && (key == K_LALT || key == K_RALT))
 		{
 			cgs.currentMenuLevel = ML_EDV;
 			return;

--- a/src/client/cl_console.c
+++ b/src/client/cl_console.c
@@ -80,7 +80,7 @@ void Con_ToggleConsole_f(void)
 			con.desiredFrac = (4.0f * SMALLCHAR_HEIGHT) / cls.glconfig.vidHeight;
 		}
 		// full console
-		else if (keys[K_ALT].down)
+		else if (keys[K_LALT].down || keys[K_RALT].down)
 		{
 			con.desiredFrac = 1.0f;
 		}

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -75,15 +75,17 @@ keyname_t keynames[] =
 	{ "LEFTARROW",       K_LEFTARROW      },
 	{ "RIGHTARROW",      K_RIGHTARROW     },
 
-	{ "ALT",             K_ALT            },
+	{ "RIGHTALT",        K_RALT           },
+	{ "LEFTALT",         K_LALT           },
+	{ "ALT",             K_LALT           },
 
-	{ "CTRL",            K_LCTRL          },
-	{ "LEFTCTRL",        K_LCTRL          },
 	{ "RIGHTCTRL",       K_RCTRL          },
-  
-	{ "SHIFT",           K_LSHIFT         },
-	{ "LEFTSHIFT",       K_LSHIFT         },
+	{ "LEFTCTRL",        K_LCTRL          },
+	{ "CTRL",            K_LCTRL          },
+
 	{ "RIGHTSHIFT",      K_RSHIFT         },
+	{ "LEFTSHIFT",       K_LSHIFT         },
+	{ "SHIFT",           K_LSHIFT         },
 
 	{ "COMMAND",         K_COMMAND        },
 
@@ -1279,7 +1281,7 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 	{
 		if (down)
 		{
-			if (keys[K_ALT].down)
+			if (keys[K_LALT].down || keys[K_RALT].down)
 			{
 				Key_ClearStates();
 				if (Cvar_VariableIntegerValue("r_fullscreen"))
@@ -1312,7 +1314,7 @@ void CL_KeyEvent(int key, qboolean down, unsigned time)
 	{
 		if (down)
 		{
-			if (keys[K_ALT].down)
+			if (keys[K_LALT].down || keys[K_RALT].down)
 			{
 				Key_ClearStates();
 				Cbuf_ExecuteText(EXEC_NOW, "minimize");

--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -458,8 +458,9 @@ static keyNum_t IN_TranslateSDLToQ3Key(SDL_Keysym *keysym, qboolean down)
 			break;
 #endif
 
-		case SDLK_RALT:
-		case SDLK_LALT:         key = K_ALT;
+		case SDLK_RALT:         key = K_RALT;
+			break;
+		case SDLK_LALT:         key = K_LALT;
 			break;
 
 		case SDLK_INSERT:       key = K_INS;

--- a/src/ui/keycodes.h
+++ b/src/ui/keycodes.h
@@ -58,15 +58,10 @@ typedef enum
 	K_LEFTARROW,
 	K_RIGHTARROW,
 
-	K_ALT,
-  
-	K_LCTRL,
-	K_RCTRL,
-	//K_SHIFT,
-	//K_CTRL,
-	K_LSHIFT,
-	K_RSHIFT,
-  
+	K_LALT,   // K_ALT
+	K_LCTRL,  // K_CTRL
+	K_LSHIFT, // K_SHIFT
+
 	K_INS,
 	K_DEL,
 	K_PGDN,
@@ -206,6 +201,10 @@ typedef enum
 
 	// Pseudo-key that brings the console down
 	K_CONSOLE,
+
+	K_RALT,
+	K_RCTRL,
+	K_RSHIFT,
 
 	MAX_KEYS
 } keyNum_t;

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -765,7 +765,7 @@ static bind_t g_bindings[] =
 	{ "+reload",          'r',             -1,  K_END,           -1,  -1, -1, -1 },
 	{ "kill",             'k',             -1,  'k',             -1,  -1, -1, -1 },
 	{ "+scores",          K_TAB,           -1,  K_TAB,           -1,  -1, -1, -1 },
-	{ "+stats",           K_ALT,           -1,  K_F9,            -1,  -1, -1, -1 },
+	{ "+stats",           K_LALT,          -1,  K_F9,            -1,  -1, -1, -1 },
 	{ "+topshots",        K_LCTRL,         -1,  K_F10,           -1,  -1, -1, -1 },
 	{ "+objectives",      'o',             -1,  'o',             -1,  -1, -1, -1 },
 	{ "toggleconsole",    '`',             '~', '`',             '~', -1, -1, -1 },


### PR DESCRIPTION
Adding right ctrl/shift keys in the middle of the enum broke all
following keys in existing UI VMs. Mouse click didn't work.

Add right alt key for completeness. Though it would probably make
sense to also add right command/super keys in the future.

Reorder keynames so that LEFTSHIFT is displayed in controls menu
instead of SHIFT.