### PR TITLE
renderer: Restore fix for foliage color/alpha on big endian systems

### DIFF
--- a/src/renderer/tr_surface.c
+++ b/src/renderer/tr_surface.c
@@ -517,7 +517,11 @@ void RB_SurfaceFoliage(srfFoliage_t *srf)
 
 			// set color
 			a        = alpha > 1.0f ? 255 : (int)(alpha * 255);
+#ifdef Q3_BIG_ENDIAN // LBO 3/15/05. Byte-swap fix for Mac - alpha is in the LSB.
+			srcColor = (*((int*) instance->color) & 0xFFFFFF00) | (a & 0xff);
+#else
 			srcColor = (*((int *) instance->color) & 0xFFFFFF) | (a << 24);
+#endif
 		}
 		else
 		{

--- a/src/renderer2/tr_surface.c
+++ b/src/renderer2/tr_surface.c
@@ -1336,7 +1336,11 @@ static void Tess_SurfaceFoliage(srfFoliage_t *srf)
 
 			// set color
 			a        = alpha > 1.0f ? 255 : alpha * 255;
+#ifdef Q3_BIG_ENDIAN // LBO 3/15/05. Byte-swap fix for Mac - alpha is in the LSB.
+			srcColor = (*((int*)instance->color) & 0xFFFFFF00) | (a & 0xff);
+#else
 			srcColor = (*((int *)instance->color) & 0xFFFFFF) | (a << 24);
+#endif
 		}
 		else
 #endif

--- a/src/rendererGLES/tr_surface.c
+++ b/src/rendererGLES/tr_surface.c
@@ -514,7 +514,11 @@ void RB_SurfaceFoliage(srfFoliage_t *srf)
 
 			// set color
 			a        = alpha > 1.0f ? 255 : (int)(alpha * 255);
+#ifdef Q3_BIG_ENDIAN // LBO 3/15/05. Byte-swap fix for Mac - alpha is in the LSB.
+			srcColor = (*((int*) instance->color) & 0xFFFFFF00) | (a & 0xff);
+#else
 			srcColor = (*((int *) instance->color) & 0xFFFFFF) | (a << 24);
+#endif
 		}
 		else
 		{


### PR DESCRIPTION
The original ET-GPL source code has a [bug fix](https://github.com/id-Software/Enemy-Territory/blob/master/src/renderer/tr_surface.c#L556-L558) for foliage color/alpha on big endian systems &mdash; such as PowerPC Mac. However it was removed from ET: Legacy in https://github.com/etlegacy/etlegacy/commit/ee04dd000bfae064cf7a55177a560d39b10a5a53. Probably due to the original ET-GPL source code checking `__MACOS__` which breaks Intel Mac behavior. This can be solved by checking `Q3_BIG_ENDIAN` instead.

I have not actually tested ET: Legacy on a big endian system so I do not know if there are other issues.