### PR TITLE
fixing fog and sorting issue

### DIFF
--- a/src/renderer2/tr_shader.c
+++ b/src/renderer2/tr_shader.c
@@ -4974,8 +4974,7 @@ static shader_t *GeneratePermanentShader(void)
 	newShader = (shader_t *)ri.Hunk_Alloc(sizeof(shader_t), h_low);
 
 	*newShader = shader;
-
-	if (shader.sort <= SS_OPAQUE) // FIXME: SS_SEE_THROUGH sort order? enum has been changes inspect!
+	if (shader.sort <= SS_SEE_THROUGH && shader.sort != SS_ENVIRONMENT_NOFOG)
 	{
 		newShader->fogPass = FP_EQUAL;
 	}


### PR DESCRIPTION
The vanilla range for fog pass setting is much bigger than what r2 has. Basically r2 has what was set in stock q3, but this breaks some stuff in et, eg. foliage fogging, since foliage sorting is SS_SEENTHROUGH which is bigger than SS_OPAQUE. This excludes SS_ENVIRONMENT_NOFOG, as the name implies, this should not have fog pass set.