### PR TITLE
fix videomaps not playing correctly

### DIFF
--- a/src/client/cl_cinematic.c
+++ b/src/client/cl_cinematic.c
@@ -583,7 +583,7 @@ e_status CIN_RunCinematic(int handle)
 {
 	cinematic_t *data;
 
-	if (!CIN_HandleValid(cls.cinematicHandle))
+	if (!CIN_HandleValid(handle))
 	{
 		return FMV_EOF;
 	}


### PR DESCRIPTION
roq files are not played correctly, if are used in shaders via videomap directive, due to a wrong handle was used to validate the handle

refs #1068