### PR TITLE
r2: fix skyshader issue with clampmap'ed textures

### DIFF
--- a/src/renderer2/tr_shader.c
+++ b/src/renderer2/tr_shader.c
@@ -1745,7 +1745,7 @@ qboolean ParseStage(shaderStage_t *stage, char **text)
 				filterType = shader.filterType;
 			}
 
-			stage->bundle[0].image[0] = R_FindImageFile(token, imageBits, filterType, WT_CLAMP, shader.name);
+			stage->bundle[0].image[0] = R_FindImageFile(token, imageBits, filterType, WT_EDGE_CLAMP, shader.name);
 			if (!stage->bundle[0].image[0])
 			{
 				Ren_Warning("WARNING: R_FindImageFile could not find '%s' in shader '%s'\n", token, shader.name);

--- a/src/renderer2/tr_sky.c
+++ b/src/renderer2/tr_sky.c
@@ -574,8 +574,8 @@ static void FillCloudySkySide(const int mins[2], const int maxs[2], qboolean add
 
 			tess.texCoords[tess.numVertexes][0] = s_skyTexCoords[t][s][0];
 			tess.texCoords[tess.numVertexes][1] = s_skyTexCoords[t][s][1];
-			tess.texCoords[tess.numVertexes][2] = s_skyTexCoords[t][s][2];
-			tess.texCoords[tess.numVertexes][3] = s_skyTexCoords[t][s][3];
+			tess.texCoords[tess.numVertexes][2] = 0;
+			tess.texCoords[tess.numVertexes][3] = 1;
 
 			tess.numVertexes++;
 


### PR DESCRIPTION
clampmap'ed textures in renderer2 were not positioned correctly in skyboxes due to getting wrong wrap setting on image initialization
refs #621