### PR TITLE
R2: tr_glsl  

### DIFF
--- a/src/renderer2/tr_glsl.c
+++ b/src/renderer2/tr_glsl.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Wolfenstein: Enemy Territory GPL Source Code
  * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
  *
@@ -1070,7 +1070,7 @@ static void GLSL_BuildShaderExtraDef()
 		BUFFEXT("#ifndef r_ParallaxMapping\n#define r_ParallaxMapping 1\n#endif\n");
 	}
 
-	if (r_wrapAroundLighting->value)
+	if (r_wrapAroundLighting->integer)
 	{
 		BUFFEXT("#ifndef r_WrapAroundLighting\n#define r_WrapAroundLighting %f\n#endif\n", r_wrapAroundLighting->value);
 	}


### PR DESCRIPTION
use integer instead of value to be able to actually turn r_wrapAroundLighting off