### PR TITLE
Fix slow regen issue with pmove_fixed 1

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1298,7 +1298,7 @@ void ClientThink_real(gentity_t *ent)
 
 	// zinx etpro antiwarp
 	client->pers.pmoveMsec = pmove_msec.integer;
-	if (G_DoAntiwarp(ent) && (pmove_fixed.integer || client->pers.pmoveFixed))
+	if (!G_DoAntiwarp(ent) && (pmove_fixed.integer || client->pers.pmoveFixed))
 	{
 		ucmd->serverTime = ((ucmd->serverTime + client->pers.pmoveMsec - 1) /
 		                    client->pers.pmoveMsec) * client->pers.pmoveMsec;


### PR DESCRIPTION
There seems to be was little error made while porting antiwrap code from etpub? etpub code has exactly exclamation mark set before the `G_DoAntiwarp` call, this is actually solves the slow regen issue when `pmove_fixed 1` is enabled.