### PR TITLE
Render2: glsl changes

### DIFF
--- a/src/renderer2/glsl/lightMapping_fp.glsl
+++ b/src/renderer2/glsl/lightMapping_fp.glsl
@@ -135,31 +135,30 @@ void main()
 	// compute half angle in world space
 	vec3 H = normalize(L + I);
 
+	//compute reflection
+	vec3 R = reflect(-L, N);
 	// compute the specular term
 	vec3 specular = texture2D(u_SpecularMap, texSpecular).rgb;
 
-	float NdotL = clamp(dot(N, L), 0.0, 1.0);
+		// compute the light term
+#if defined(r_HalfLambertLighting)
+	// http://developer.valvesoftware.com/wiki/Half_Lambert
+	float NL = dot(N, L) * 0.5 + 0.5;
+#elif defined(r_WrapAroundLighting)
+	float NL = clamp(dot(N, L) + u_LightWrapAround, 0.0, 1.0) / clamp(1.0 + u_LightWrapAround, 0.0, 1.0);
+#else
+	float NL = clamp(dot(N, L), 0.0, 1.0);
+#endif
 
 	// compute light color from world space lightmap
-	vec3 lightColor = lightmapColor.rgb * NdotL;
+	vec3 lightColor = lightmapColor.rgb * NL;
 
-	float NdotLnobump = clamp(dot(normalize(var_Normal.xyz), L), 0.004, 1.0);
-	//vec3 lightColorNoNdotL = clamp(lightColor.rgb / NdotLnobump, 0.0, 1.0);
-
-	//float NdotLnobump = dot(normalize(var_Normal.xyz), L);
-	vec3 lightColorNoNdotL = lightColor.rgb / NdotLnobump;
+	
 
 	// compute final color
 	vec4 color = diffuse;
-	// color = vec4(vec3(1.0, 1.0, 1.0), diffuse.a);
-	//color.rgb = vec3(NdotLnobump, NdotLnobump, NdotLnobump);
-	//color.rgb *= lightColor.rgb;
-	//color.rgb = lightColorNoNdotL.rgb * NdotL;
-	//color.rgb *= clamp(lightColorNoNdotL.rgb * NdotL, lightColor.rgb * 1.0, lightColor.rgb);
-	//color.rgb *= diffuse.rgb;
-	//color.rgb = L * 0.5 + 0.5;
 	color.rgb *= lightColor;
-	color.rgb += specular * lightColor * pow(clamp(dot(N, H), 0.0, 1.0), r_SpecularExponent) * r_SpecularScale;
+	color.rgb += specular * lightColor * pow(max(dot(I, R), 0.0), r_SpecularExponent) * r_SpecularScale;
 	// for smooth terrain blending
 	color.a   *= var_Color.a; 
 

--- a/src/renderer2/glsl/lightMapping_fp.glsl
+++ b/src/renderer2/glsl/lightMapping_fp.glsl
@@ -210,7 +210,7 @@ void main()
 	color.a   *= var_Color.a; 
 #endif
 
-	gl_FragColor = color;
+	
 
 	if (SHOW_DELUXEMAP)
 	{

--- a/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
+++ b/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
@@ -136,7 +136,7 @@ void main()
 	vec3 light = var_LightColor.rgb * NL;
 
 	// compute the specular term
-	//vec3 specular = texture2D(u_SpecularMap, texSpecular).rgb * var_LightColor.rgb * pow(clamp(dot(N, H), 0.0, 1.0), r_SpecularExponent) * r_SpecularScale;
+	
 	vec3 specular = texture2D(u_SpecularMap, texSpecular).rgb * var_LightColor.rgb * pow(max(dot(V, R), 0.0), r_SpecularExponent) * r_SpecularScale;
 	
 	// compute final color

--- a/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
+++ b/src/renderer2/glsl/vertexLighting_DBS_world_fp.glsl
@@ -29,6 +29,8 @@ void main()
 			return;
 		}
 	#endif
+	// compute view direction in world space
+	vec3 V = normalize (u_ViewOrigin - var_Position);
 
 #if defined(USE_NORMAL_MAPPING)
 
@@ -50,8 +52,7 @@ void main()
 		                             var_Tangent.z, var_Binormal.z, var_Normal.z);
 	}
 
-	// compute view direction in tangent space
-	vec3 V = normalize(objectToTangentMatrix * (u_ViewOrigin - var_Position));
+	
 
 	vec2 texDiffuse  = var_TexDiffuseNormal.st;
 	vec2 texNormal   = var_TexDiffuseNormal.pq;

--- a/src/renderer2/tr_shade.c
+++ b/src/renderer2/tr_shade.c
@@ -862,6 +862,11 @@ static void Render_lightMapping(int stage, qboolean asColorMap, qboolean normalM
 	GLSL_SetUniform_ColorModulate(trProg.gl_lightMappingShader, rgbaGen.color, rgbaGen.alpha);
 	SetUniformVec4(UNIFORM_COLOR, tess.svars.color);
 
+	if (r_wrapAroundLighting->integer)
+	{
+		SetUniformFloat(UNIFORM_LIGHTWRAPAROUND, RB_EvalExpression(&pStage->wrapAroundLightingExp, 0));
+	}
+
 	if (r_parallaxMapping->integer)
 	{
 		float depthScale;

--- a/src/renderer2/tr_shader.c
+++ b/src/renderer2/tr_shader.c
@@ -4396,13 +4396,14 @@ static qboolean ParseShader(char *_text)
 			//Ren_Warning( "WARNING: keyword '%s' not supported in shader '%s'\n", token, shader.name);
 			//SkipRestOfLine(text);
 
-			// set implicit mapping state
+			/*// set implicit mapping state
+			NOTE: FIXE.. todo check thru all combinations of blending
 			if (!Q_stricmp(token, "implicitBlend"))
 			{
 				implicitStateBits = GLS_DEPTHMASK_TRUE | GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA;
 				implicitCullType  = CT_TWO_SIDED;
-			}
-			else if (!Q_stricmp(token, "implicitMask"))
+			}*/
+			if (!Q_stricmp(token, "implicitBlend")|| (!Q_stricmp(token, "implicitMask")))
 			{
 				implicitStateBits = GLS_DEPTHMASK_TRUE | GLS_ATEST_GE_128;
 				implicitCullType  = CT_TWO_SIDED;


### PR DESCRIPTION
Give glsl shaders same light calculation, this is actually a bit important if we want the outcome to be close to correct, moved the viewOrigin in vertexworld shader, not really important but either way correct to have it for bot normalmapping and generic.