### PR TITLE
Update bg_misc.c

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -4440,7 +4440,7 @@ qboolean PC_String_ParseNoAlloc(int handle, char *out, size_t size)
 
 const char *bg_fireteamNames[MAX_FIRETEAMS / 2] =
 {
-	"Alfa",
+	"Alpha",
 	"Bravo",
 	"Charlie",
 	"Delta",


### PR DESCRIPTION
I realize you have had that discussion already, but can we please change it back to Fireteam ALPHA?
It has always been like that and ALFA just looks wrong. Phonetic alphabet or not. This is not about realism, because if it were, then we would need to use Able, Baker etc. for Allies like spyhawk already pointed out in the commit. We would also need to use swastikas instead of Wolflogos, but that again is a different story....Everywhere in the game "alpha" is used. 

I'd argue that whoever decided to use "ALFA" in the official phonetic ALPHABET is already wrong.
It's called ALPHABET and not ALFABET for a reason, but that doesn't concern the game.

I don't see the benefit we get from changing 15 years. This doesn't provide a feature, nor is it actually a typo or anything. It just different for the sake of changing it.....at least in my eyes....