### PR TITLE
Render2 : Hello worldbsp

### DIFF
--- a/src/renderer2/tr_init.c
+++ b/src/renderer2/tr_init.c
@@ -242,7 +242,7 @@ cvar_t *r_vboModels;
 cvar_t *r_vboVertexSkinning;
 cvar_t *r_vboSmoothNormals;
 cvar_t *r_vboFoliage;
-
+cvar_t *r_worldBsp;
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 cvar_t *r_mergeClusterSurfaces;
 cvar_t *r_mergeClusterFaces;
@@ -1254,7 +1254,7 @@ void R_Register(void)
 	r_vboVertexSkinning   = ri.Cvar_Get("r_vboVertexSkinning", "1", CVAR_ARCHIVE | CVAR_LATCH);
 	r_vboSmoothNormals    = ri.Cvar_Get("r_vboSmoothNormals", "1", CVAR_ARCHIVE | CVAR_LATCH);
 	r_vboFoliage = ri.Cvar_Get("r_vboFoliage", "1", CVAR_ARCHIVE | CVAR_LATCH);
-
+	r_worldBsp = ri.Cvar_Get("r_worldBsp","1", CVAR_ARCHIVE | CVAR_LATCH);
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 	r_mergeClusterSurfaces  = ri.Cvar_Get("r_mergeClusterSurfaces", "0", CVAR_CHEAT);
 	r_mergeClusterFaces     = ri.Cvar_Get("r_mergeClusterFaces", "1", CVAR_CHEAT);

--- a/src/renderer2/tr_init.c
+++ b/src/renderer2/tr_init.c
@@ -242,7 +242,7 @@ cvar_t *r_vboModels;
 cvar_t *r_vboVertexSkinning;
 cvar_t *r_vboSmoothNormals;
 cvar_t *r_vboFoliage;
-cvar_t *r_worldBsp;
+cvar_t *r_worldinlineModels;
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 cvar_t *r_mergeClusterSurfaces;
 cvar_t *r_mergeClusterFaces;
@@ -1254,7 +1254,7 @@ void R_Register(void)
 	r_vboVertexSkinning   = ri.Cvar_Get("r_vboVertexSkinning", "1", CVAR_ARCHIVE | CVAR_LATCH);
 	r_vboSmoothNormals    = ri.Cvar_Get("r_vboSmoothNormals", "1", CVAR_ARCHIVE | CVAR_LATCH);
 	r_vboFoliage = ri.Cvar_Get("r_vboFoliage", "1", CVAR_ARCHIVE | CVAR_LATCH);
-	r_worldBsp = ri.Cvar_Get("r_worldBsp","1", CVAR_ARCHIVE | CVAR_LATCH);
+	r_worldinlineModels = ri.Cvar_Get("r_worldinlineModels","1", CVAR_ARCHIVE | CVAR_LATCH);
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 	r_mergeClusterSurfaces  = ri.Cvar_Get("r_mergeClusterSurfaces", "0", CVAR_CHEAT);
 	r_mergeClusterFaces     = ri.Cvar_Get("r_mergeClusterFaces", "1", CVAR_CHEAT);

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -3866,7 +3866,7 @@ extern cvar_t *r_vboModels;
 extern cvar_t *r_vboVertexSkinning;
 extern cvar_t *r_vboSmoothNormals;
 extern cvar_t *r_vboFoliage;
-extern cvar_t *r_worldBsp;
+extern cvar_t *r_worldinlineModels;
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 extern cvar_t *r_mergeClusterSurfaces;
 extern cvar_t *r_mergeClusterFaces;

--- a/src/renderer2/tr_local.h
+++ b/src/renderer2/tr_local.h
@@ -3866,7 +3866,7 @@ extern cvar_t *r_vboModels;
 extern cvar_t *r_vboVertexSkinning;
 extern cvar_t *r_vboSmoothNormals;
 extern cvar_t *r_vboFoliage;
-
+extern cvar_t *r_worldBsp;
 #if defined(USE_BSP_CLUSTERSURFACE_MERGING)
 extern cvar_t *r_mergeClusterSurfaces;
 extern cvar_t *r_mergeClusterFaces;

--- a/src/renderer2/tr_shade.c
+++ b/src/renderer2/tr_shade.c
@@ -3138,7 +3138,20 @@ void Tess_StageIteratorGeneric()
 					}
 					else if (backEnd.currentEntity != &tr.worldEntity)
 					{
-						Render_vertexLighting_DBS_entity(stage);
+						if (!r_worldBsp->integer)
+						{
+							Render_vertexLighting_DBS_entity(stage);
+						}
+						model_t *pmodel;
+						pmodel = R_GetModelByHandle(backEnd.currentEntity->e.hModel);
+						if (pmodel->bsp && r_worldBsp->integer)
+						{
+							Render_vertexLighting_DBS_world(stage);
+						}
+						else if (!pmodel->bsp)
+						{
+							Render_vertexLighting_DBS_entity(stage);
+						}
 					}
 					else
 					{

--- a/src/renderer2/tr_shade.c
+++ b/src/renderer2/tr_shade.c
@@ -3138,20 +3138,17 @@ void Tess_StageIteratorGeneric()
 					}
 					else if (backEnd.currentEntity != &tr.worldEntity)
 					{
-						if (!r_worldBsp->integer)
-						{
-							Render_vertexLighting_DBS_entity(stage);
-						}
 						model_t *pmodel;
 						pmodel = R_GetModelByHandle(backEnd.currentEntity->e.hModel);
-						if (pmodel->bsp && r_worldBsp->integer)
+						if (pmodel->bsp && r_worldinlineModels->integer)
 						{
 							Render_vertexLighting_DBS_world(stage);
 						}
-						else if (!pmodel->bsp)
+						else
 						{
 							Render_vertexLighting_DBS_entity(stage);
 						}
+						
 					}
 					else
 					{


### PR DESCRIPTION
Introducing r_worldBsp that is set "1" by default for old behavior of
bspmodels and will then render as world.
setting it to 0 will result in xreal render as entity for bspmodel