### PR TITLE
renderer: fix crash caused by func_explosive

### DIFF
--- a/src/renderer/tr_image.c
+++ b/src/renderer/tr_image.c
@@ -1671,6 +1671,10 @@ qhandle_t RE_GetShaderFromModel(qhandle_t modelid, int surfnum, int withlightmap
 			msurface_t *surf;
 			shader_t   *shd;
 
+			if (bmodel->numSurfaces == 0) {
+				return 0;
+			}
+
 			if (surfnum >= bmodel->numSurfaces)     // if it's out of range, return the first surface
 			{
 				surfnum = 0;

--- a/src/renderer2/tr_skin.c
+++ b/src/renderer2/tr_skin.c
@@ -210,9 +210,15 @@ qhandle_t RE_GetShaderFromModel(qhandle_t modelid, int surfnum, int withlightmap
 		bmodel = model->bsp;
 		if (bmodel && bmodel->firstSurface)
 		{
+			if (bmodel->numSurfaces == 0) {
+				Ren_Print("RE_GetShaderFromModel warning: no surface was found.\n");
+				return 0;
+			}
+
+			// if it's out of range, use the first surface
 			if (surfnum >= bmodel->numSurfaces)
-			{                   // if it's out of range, return the first surface
-				Ren_Print("RE_GetShaderFromModel warning: surface is our of range.\n");
+			{                   
+				Ren_Print("RE_GetShaderFromModel warning: surface is out of range.\n");
 				surfnum = 0;
 			}
 


### PR DESCRIPTION
* `func_explosive` assigned to nodraw brush + using `USE_SHADER` spawnflag, will lead to a crash on release builds.
* When `RE_GetShaderFromModel` function is called for such brushmodel, it wont have any surfaces to work with, but due to no checks are made it keeps going on further, successfully surpassing the shader check on a release builds, and getting further to `surf->shader->lightmapIndex` would crash the game.
* Simple surface count check helps to fix the issue.