### PR TITLE
game: fix configs are not loaded

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -90,13 +90,13 @@ init
   setl g_mapscriptdirectory "mapscripts"
   setl g_mapConfigs ""
 
-  setl skill_battlesense "-1"
-  setl skill_engineer "-1"
-  setl skill_medic "-1"
-  setl skill_fieldops "-1"
-  setl skill_lightweapons "-1"
-  setl skill_soldier "-1"
-  setl skill_covertops "-1"
+  setl skill_battlesense -1
+  setl skill_engineer -1
+  setl skill_medic -1
+  setl skill_fieldops -1
+  setl skill_lightweapons -1
+  setl skill_soldier -1
+  setl skill_covertops -1
 
   setl g_intermissiontime 20
   setl g_multiview 0

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -90,13 +90,13 @@ init
   setl g_mapscriptdirectory "mapscripts"
   setl g_mapConfigs ""
 
-  setl skill_battlesense "-1"
-  setl skill_engineer "-1"
-  setl skill_medic "-1"
-  setl skill_fieldops "-1"
-  setl skill_lightweapons "-1"
-  setl skill_soldier "-1"
-  setl skill_covertops "-1"
+  setl skill_battlesense -1
+  setl skill_engineer -1
+  setl skill_medic -1
+  setl skill_fieldops -1
+  setl skill_lightweapons -1
+  setl skill_soldier -1
+  setl skill_covertops -1
 
   setl g_intermissiontime 20
   setl g_multiview 0

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -89,13 +89,13 @@ init
   setl g_mapscriptdirectory "mapscripts"
   setl g_mapConfigs ""
 
-  setl skill_battlesense "-1"
-  setl skill_engineer "-1"
-  setl skill_medic "-1"
-  setl skill_fieldops "-1"
-  setl skill_lightweapons "-1"
-  setl skill_soldier "-1"
-  setl skill_covertops "-1"
+  setl skill_battlesense -1
+  setl skill_engineer -1
+  setl skill_medic -1
+  setl skill_fieldops -1
+  setl skill_lightweapons -1
+  setl skill_soldier -1
+  setl skill_covertops -1
 
   setl g_intermissiontime 20
   setl g_multiview 0


### PR DESCRIPTION
Fixes legacy configs loading.

On a side note:
The `-` parser is borked and imo should be completely removed: if legit string with leading `-` provided to a cvar, it will just break the parsing again...

Basically if it finds the `-` token, it asks for the next token to validate the value presence, and next token can be the one on the next line. (`setl`). However this only happens if the value is enquoted.
https://github.com/etlegacy/etlegacy/blob/4aceb87a03f843d57439bc55260bf599a53807c4/src/game/g_config.c#L204-L212

I suggest to remove it, since there is no great way to check a value type to perform the minus check.