### PR TITLE
Fixed spelling of the Swedish locale

### DIFF
--- a/etmain/locale/etlegacy_mod.pot
+++ b/etmain/locale/etlegacy_mod.pot
@@ -7400,7 +7400,7 @@ msgstr ""
 msgid "Serbian"
 msgstr ""
 
-msgid "Swedisch"
+msgid "Swedish"
 msgstr ""
 
 msgid "desktop resolution"

--- a/etmain/ui/menumacros.h
+++ b/etmain/ui/menumacros.h
@@ -38,7 +38,8 @@
 
 #define LEGACY_RESOLUTIONS cvarFloatList { "desktop resolution" - 2 "custom resolution" - 1 "640*480" 3 "800*600" 4 "960*720" 5 "1024*768" 6 "1152*864" 7 "1280*1024" 8 "1600*1200" 9 "2048*1536" 10 "856*480 Wide Screen" 11 "1366x768 (16:9)" 12 "1440x900 (16:10)" 13 "1680x1050 (16:10)" 14 "1600x1200" 15 "1920x1080 (16:9)" 16 "1920x1200 (16:10)" 17 "2560x1440 (16:9)" 18 "2560x1600 (16:10)" 19 "3840x2160 (16:9)" 20 }
 #define LEGACY_WINDOWMODES cvarFloatList { "Windowed" 0 "Fullscreen" 1 "Windowed Fullscreen" 2 }
-#define LEGACY_LANGUAGES   cvarStrList { "English (default)  "; "en"; "Bulgarian"; "bg"; "Czech"; "cs"; "Dutch"; "nl"; "Finnish"; "fi"; "French"; "fr"; "German"; "de"; "Greek"; "el"; "Hungarian"; "hu"; "Italian"; "it"; "Norwegian"; "no"; "Polish"; "pl"; "Portuguese"; "pt"; "Russian"; "ru"; "Serbian"; "sr"; "Spanish"; "es"; "Swedisch"; "sv"; "Turkish"; "tr"; }
+#define LEGACY_LANGUAGES   cvarStrList { "English (default)  "; "en"; "Bulgarian"; "bg"; "Czech"; "cs"; "Dutch"; "nl"; "Finnish"; "fi"; "French"; "fr"; "German"; "de"; "Greek"; "el"; "Hungarian"; "hu"; 
+"Italian"; "it"; "Norwegian"; "no"; "Polish"; "pl"; "Portuguese"; "pt"; "Russian"; "ru"; "Serbian"; "sr"; "Spanish"; "es"; "Swedish"; "sv"; "Turkish"; "tr"; }
 #define LEGACY_RENDERERS   cvarStrList { "Vanilla (default)  "; "opengl1"; "ET: Legacy"; "opengl2" }
 
 // Marks text as translatable


### PR DESCRIPTION
[Relevant task on the issue tracker](https://dev.etlegacy.com/issues/1121).

I did a quick search of "Swedisch" and was able to find these two locations.