### PR TITLE
game: remove useless checks

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2071,15 +2071,6 @@ void Cmd_Team_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue)
 	}
 
 	ent->client->sess.latchPlayerType = playerType;
-	if (ent->client->sess.latchPlayerType < PC_SOLDIER || ent->client->sess.latchPlayerType > PC_COVERTOPS)
-	{
-		ent->client->sess.latchPlayerType = PC_SOLDIER;
-	}
-
-	if (ent->client->sess.latchPlayerType < PC_SOLDIER || ent->client->sess.latchPlayerType > PC_COVERTOPS)
-	{
-		ent->client->sess.latchPlayerType = PC_SOLDIER;
-	}
 
 	if (!SetTeam(ent, s, qfalse, w, w2, qtrue))
 	{


### PR DESCRIPTION
_playerType_ is already validated/changed above: https://github.com/etlegacy/etlegacy/blob/5406fd481cb72501e13fed64eea2faa7ac954abf/src/game/g_cmds.c#L2053-L2056
It is affected and re-checked twice: https://github.com/etlegacy/etlegacy/blob/5406fd481cb72501e13fed64eea2faa7ac954abf/src/game/g_cmds.c#L2073-L2082
This commit removes both of these unnecessary checks