### PR TITLE
game: added g_stickycharge cvar

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2652,6 +2652,14 @@ static char *G_CheckVersion(gentity_t *ent)
 }
 #endif
 
+static qboolean isMortalSelfDamage(gentity_t *ent) {
+	return (
+		(ent->enemy && ent->enemy->s.number >= MAX_CLIENTS) // worldkill
+		|| (ent->enemy == ent) // selfkill
+		|| OnSameTeam(ent->enemy, ent) // teamkill
+	);
+}
+
 /**
  * @brief Called every time a client is placed fresh in the world:
  * after the first ClientBegin, and after each respawn
@@ -2793,8 +2801,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 
 	// Reset/restore special weapon time
 	if (
-		((g_stickyCharge.integer & STICKYCHARGE_SLASHKILL) && client->pers.slashKill) ||
-		(g_stickyCharge.integer & STICKYCHARGE_ANYDEATH)
+		((g_stickyCharge.integer & STICKYCHARGE_SELFKILL) && isMortalSelfDamage(ent))
+		|| (g_stickyCharge.integer & STICKYCHARGE_ANYDEATH)
 	) {
 		switch (client->sess.latchPlayerType) {
 		case PC_MEDIC:
@@ -3060,8 +3068,6 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	{
 		G_ResetTeamMapData();
 	}
-
-	client->pers.slashKill = qfalse;
 }
 
 /**

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -810,6 +810,26 @@ void limbo(gentity_t *ent, qboolean makeCorpse)
 			ent->client->saved_persistant[i] = ent->client->ps.persistant[i];
 		}
 
+		if (g_stickyCharge.integer > 0 && ent->client->ps.classWeaponTime >= 0) {
+			switch (ent->client->sess.playerType) {
+			case PC_MEDIC:
+				ent->client->pers.savedClassWeaponTimeMed = level.time - ent->client->ps.classWeaponTime;
+				break;
+			case PC_ENGINEER:
+				ent->client->pers.savedClassWeaponTimeEng = level.time - ent->client->ps.classWeaponTime;
+				break;
+			case PC_FIELDOPS:
+				ent->client->pers.savedClassWeaponTimeFop = level.time - ent->client->ps.classWeaponTime;
+				break;
+			case PC_COVERTOPS:
+				ent->client->pers.savedClassWeaponTimeCvop = level.time - ent->client->ps.classWeaponTime;
+				break;
+			default:
+				ent->client->pers.savedClassWeaponTime = level.time - ent->client->ps.classWeaponTime;
+			}
+		}
+
+
 		ent->client->ps.pm_flags |= PMF_LIMBO;
 		ent->client->ps.pm_flags |= PMF_FOLLOW;
 
@@ -1138,9 +1158,6 @@ void SetWolfSpawnWeapons(gclient_t *client)
 #endif
 
 	classInfo = BG_GetPlayerClassInfo(team, pc);
-
-	// Reset special weapon time
-	client->ps.classWeaponTime = -999999;
 
 	// Communicate it to cgame
 	client->ps.stats[STAT_PLAYER_CLASS] = pc;
@@ -2389,6 +2406,12 @@ void ClientBegin(int clientNum)
 	client->pers.lastteambleed_client = -1;
 	client->pers.lastteambleed_dmg    = -1;
 
+	client->pers.savedClassWeaponTime = -999999;
+	client->pers.savedClassWeaponTimeCvop = -999999;
+	client->pers.savedClassWeaponTimeEng = -999999;
+	client->pers.savedClassWeaponTimeFop = -999999;
+	client->pers.savedClassWeaponTimeMed = -999999;
+
 #ifdef FEATURE_OMNIBOT
 	// Omni-bot
 	client->sess.botSuicide = qfalse; // make sure this is not set
@@ -2652,6 +2675,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	int                flags;
 	int                savedPing;
 	int                savedTeam;
+	int                savedDeathTime;
 	qboolean           inIntermission = (g_gamestate.integer == GS_INTERMISSION && client->ps.pm_type == PM_INTERMISSION) ? qtrue : qfalse;
 
 	G_UpdateSpawnCounts();
@@ -2717,6 +2741,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	savedSess = client->sess;
 	savedPing = client->ps.ping;
 	savedTeam = client->ps.teamNum;
+	savedDeathTime = client->deathTime;
 
 	for (i = 0 ; i < MAX_PERSISTANT ; i++)
 	{
@@ -2764,6 +2789,46 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	// clear entity values
 	client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
 	client->ps.eFlags                 = flags;
+	client->deathTime = savedDeathTime;
+
+	// Reset/restore special weapon time
+	if (
+		((g_stickyCharge.integer & STICKYCHARGE_SLASHKILL) && client->pers.slashKill) ||
+		(g_stickyCharge.integer & STICKYCHARGE_ANYDEATH)
+	) {
+		switch (client->sess.latchPlayerType) {
+		case PC_MEDIC:
+			client->ps.classWeaponTime = client->pers.savedClassWeaponTimeMed;
+			break;
+		case PC_ENGINEER:
+			client->ps.classWeaponTime = client->pers.savedClassWeaponTimeEng;
+			break;
+		case PC_FIELDOPS:
+			client->ps.classWeaponTime = client->pers.savedClassWeaponTimeFop;
+			break;
+		case PC_COVERTOPS:
+			client->ps.classWeaponTime = client->pers.savedClassWeaponTimeCvop;
+			break;
+		default:
+			client->ps.classWeaponTime = client->pers.savedClassWeaponTime;
+		}
+
+		if (client->ps.classWeaponTime >= 0) {
+			// class change
+			if (client->sess.playerType != client->sess.latchPlayerType) {
+				// restore the weapon time as it was on the moment of death
+				client->ps.classWeaponTime = level.time - client->ps.classWeaponTime;
+			}
+			else
+			{
+				// compenstate limbo time
+				client->ps.classWeaponTime = savedDeathTime - client->ps.classWeaponTime;
+			}
+		}
+	}
+	else {
+		client->ps.classWeaponTime = -999999;
+	}
 
 	ent->s.groundEntityNum = ENTITYNUM_NONE;
 	ent->client            = &level.clients[index];
@@ -2995,6 +3060,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	{
 		G_ResetTeamMapData();
 	}
+
+	client->pers.slashKill = qfalse;
 }
 
 /**

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1113,7 +1113,6 @@ void Cmd_Kill_f(gentity_t *ent)
 	ent->flags                                  &= ~FL_GODMODE;
 	ent->client->ps.stats[STAT_HEALTH]           = ent->health = 0;
 	ent->client->ps.persistant[PERS_HWEAPON_USE] = 0; // if using /kill while at MG42
-	ent->client->pers.slashKill = qtrue;
 
 	player_die(ent, ent, ent, (g_gamestate.integer == GS_PLAYING) ? 100000 : 135, MOD_SUICIDE);
 }

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1113,6 +1113,7 @@ void Cmd_Kill_f(gentity_t *ent)
 	ent->flags                                  &= ~FL_GODMODE;
 	ent->client->ps.stats[STAT_HEALTH]           = ent->health = 0;
 	ent->client->ps.persistant[PERS_HWEAPON_USE] = 0; // if using /kill while at MG42
+	ent->client->pers.slashKill = qtrue;
 
 	player_die(ent, ent, ent, (g_gamestate.integer == GS_PLAYING) ? 100000 : 135, MOD_SUICIDE);
 }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -819,7 +819,6 @@ typedef struct
 	int lastteambleed_client;
 	int lastteambleed_dmg;
 
-	qboolean slashKill;
 	int savedClassWeaponTimeMed;
 	int savedClassWeaponTimeEng;
 	int savedClassWeaponTimeFop;
@@ -2067,7 +2066,7 @@ extern vmCvar_t g_multiview;
 #endif
 
 #define STICKYCHARGE_NONE 0 // default, reset charge on any death
-#define STICKYCHARGE_SLASHKILL 1 // keep charge after /kill
+#define STICKYCHARGE_SELFKILL 1 // keep charge after selfkill, mortal self damage, teamkill, mortal world damage
 #define STICKYCHARGE_ANYDEATH 2 // keep charge after any death (for eg. death by enemy)
 extern vmCvar_t g_stickyCharge;
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -819,6 +819,13 @@ typedef struct
 	int lastteambleed_client;
 	int lastteambleed_dmg;
 
+	qboolean slashKill;
+	int savedClassWeaponTimeMed;
+	int savedClassWeaponTimeEng;
+	int savedClassWeaponTimeFop;
+	int savedClassWeaponTimeCvop;
+	int savedClassWeaponTime;
+
 } clientPersistant_t;
 
 /**
@@ -2058,6 +2065,11 @@ extern vmCvar_t g_skillRating;
 #ifdef FEATURE_MULTIVIEW
 extern vmCvar_t g_multiview;
 #endif
+
+#define STICKYCHARGE_NONE 0 // default, reset charge on any death
+#define STICKYCHARGE_SLASHKILL 1 // keep charge after /kill
+#define STICKYCHARGE_ANYDEATH 2 // keep charge after any death (for eg. death by enemy)
+extern vmCvar_t g_stickyCharge;
 
 /**
  * @struct GeoIPTag

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -345,6 +345,8 @@ vmCvar_t g_skillRating;
 vmCvar_t g_multiview; // 0 - off, other - enabled
 #endif
 
+vmCvar_t g_stickyCharge; 
+
 cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
@@ -626,6 +628,7 @@ cvarTable_t gameCvarTable[] =
 #ifdef FEATURE_MULTIVIEW
 	{ &g_multiview,                         "g_multiview",                         "0",                          CVAR_LATCH | CVAR_ARCHIVE,                       0, qfalse, qfalse },
 #endif
+	{ &g_stickyCharge,                      "g_stickyCharge",                      "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 };
 
 /**


### PR DESCRIPTION
`g_stickyCharge` controls when powerbar is restored or refilled, it follows etpro's `b_stickycharge` behavior:
`client's powerbar refills completely (0) or gradually after suicide (1) / any death (2)`.
Each class stores own charge value. The charge keeps refilling in limbo unless player changes the class.