### PR TITLE
game: fix stopwatch restart after round end

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4009,6 +4009,13 @@ void CheckExitRules(void)
 	// signal ready, then go to next level
 	if (g_gamestate.integer == GS_INTERMISSION)
 	{
+		// if ExitLevel has run, but still no new map was loaded, try restarting the map
+		if (level.intermissiontime == 0) {
+			G_Printf("^3%s\n", "WARNING: failed to load the next map or campaign!");
+			G_Printf("^3%s\n", "Restarting level...");
+			trap_SendConsoleCommand(EXEC_APPEND, "map_restart 0\n");
+			return;
+		}
 		CheckIntermissionExit();
 		return;
 	}


### PR DESCRIPTION
It's not as much about the stopwatch as the fact that the stopwatch and some other gametypes were dependent on the `nextmap` cvar, wich is executed after the intermission, which normally contains the `map_restart` command, the issue appears when competitive configs are loaded, and the `nextmap` cvariable gets reset (by design), this works fine on etpro, but ported configs didn't work great on legacy because the way nextmap was handled. This little patch tries to emulate the behavior adopted by the etpro, to increase the portability of the etpro server configs.