### PR TITLE
ui: add directives to color scrollbar and slider

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -2674,6 +2674,12 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cgs.screenXScale = cgs.glconfig.vidWidth / 640.0f;
 	cgs.screenYScale = cgs.glconfig.vidHeight / 480.0f;
 
+
+	if (cg.legacyClient <= 0)
+	{
+		cgs.glconfig.windowAspect = (float)cgs.glconfig.vidWidth / (float)cgs.glconfig.vidHeight;
+	}
+
 	// screen support ...
 	cgs.adr43       = cgs.glconfig.windowAspect * RPRATIO43;       // aspectratio / (4/3)
 	cgs.r43da       = RATIO43 * 1.0f / cgs.glconfig.windowAspect;  // (4/3) / aspectratio

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1284,6 +1284,9 @@ void UI_LoadMenus(const char *menuFile, qboolean reset)
 		trap_PC_AddGlobalDefine("LEGACY");
 	}
 
+	trap_PC_AddGlobalDefine(va("__WINDOW_WIDTH %f", (uiInfo.uiDC.glconfig.windowAspect / RATIO43) * 640 ));
+	trap_PC_AddGlobalDefine("__WINDOW_HEIGHT 480");
+
 	handle = trap_PC_LoadSource(menuFile);
 	if (!handle)
 	{
@@ -7890,6 +7893,11 @@ void UI_Init(int legacyClient, int clientVersion)
 	}
 
 	MOD_CHECK_LEGACY(legacyClient, clientVersion, uiInfo.legacyClient);
+
+	if (uiInfo.legacyClient <= 0)
+	{
+		uiInfo.uiDC.glconfig.windowAspect = (float)uiInfo.uiDC.glconfig.vidWidth / (float)uiInfo.uiDC.glconfig.vidHeight;
+	}
 
 	//UI_Load();
 	uiInfo.uiDC.registerShaderNoMip  = &trap_R_RegisterShaderNoMip;

--- a/src/ui/ui_menuitem.c
+++ b/src/ui/ui_menuitem.c
@@ -2986,23 +2986,19 @@ void Item_Combo_Paint(itemDef_t *item)
  */
 void Item_Slider_Paint(itemDef_t *item)
 {
-	vec4_t    newColor;
+	vec4_t    sliderColor;
 	float     x, y;
 	menuDef_t *parent = (menuDef_t *)item->parent;
 
 	if ((item->window.flags & WINDOW_HASFOCUS) && (item->window.flags & WINDOW_FOCUSPULSE))
 	{
-		vec4_t lowLight;
-
-		lowLight[0] = 0.8f * parent->focusColor[0];
-		lowLight[1] = 0.8f * parent->focusColor[1];
-		lowLight[2] = 0.8f * parent->focusColor[2];
-		lowLight[3] = 0.8f * parent->focusColor[3];
-		LerpColor(parent->focusColor, lowLight, newColor, 0.5f + 0.5f * (float)(sin(DC->realTime / PULSE_DIVISOR)));
+		vec4_t dimmedColor;
+		VectorScale(item->sliderColor, 0.8, dimmedColor);
+		LerpColor(item->sliderColor, dimmedColor, sliderColor, 0.5f + 0.5f * (float)(sin(DC->realTime / PULSE_DIVISOR)));
 	}
 	else
 	{
-		Com_Memcpy(&newColor, &item->window.foreColor, sizeof(vec4_t));
+		Vector4Copy(item->sliderColor, sliderColor);
 	}
 
 	y = item->window.rect.y;
@@ -3016,11 +3012,12 @@ void Item_Slider_Paint(itemDef_t *item)
 		x = item->window.rect.x;
 	}
 
-	DC->setColor(newColor);
+	DC->setColor(sliderColor);
 	DC->drawHandlePic(x, y + 1, SLIDER_WIDTH, SLIDER_HEIGHT, DC->Assets.sliderBar);
 
 	x = Item_Slider_ThumbPosition(item);
 	DC->drawHandlePic(x - (SLIDER_THUMB_WIDTH / 2), y, SLIDER_THUMB_WIDTH, SLIDER_THUMB_HEIGHT, DC->Assets.sliderThumb);
+	DC->setColor(NULL);
 }
 
 /**
@@ -3375,6 +3372,7 @@ void Item_ListBox_Paint(itemDef_t *item)
 		// bar
 		x = fillRect.x + 1;
 		y = fillRect.y + fillRect.h - SCROLLBAR_SIZE - 1;
+		DC->setColor(item->scrollColor);
 		DC->drawHandlePic(x, y, SCROLLBAR_SIZE, SCROLLBAR_SIZE, DC->Assets.scrollBarArrowLeft);
 		x   += SCROLLBAR_SIZE - 1;
 		size = fillRect.w - (SCROLLBAR_SIZE * 2);
@@ -3389,6 +3387,7 @@ void Item_ListBox_Paint(itemDef_t *item)
 		}
 
 		DC->drawHandlePic(thumb, y, SCROLLBAR_SIZE, SCROLLBAR_SIZE, DC->Assets.scrollBarThumb);
+		DC->setColor(NULL);
 
 		listPtr->endPos = listPtr->startPos;
 		size            = fillRect.w - 2;
@@ -3431,6 +3430,7 @@ void Item_ListBox_Paint(itemDef_t *item)
 		// draw scrollbar to right side of the window
 		x = fillRect.x + fillRect.w - SCROLLBAR_SIZE - 1;
 		y = fillRect.y + 1;
+		DC->setColor(item->scrollColor);
 		DC->drawHandlePic(x, y, SCROLLBAR_SIZE, SCROLLBAR_SIZE, DC->Assets.scrollBarArrowUp);
 		y += SCROLLBAR_SIZE - 1;
 
@@ -3447,6 +3447,7 @@ void Item_ListBox_Paint(itemDef_t *item)
 		}
 
 		DC->drawHandlePic(x, thumb, SCROLLBAR_SIZE, SCROLLBAR_SIZE, DC->Assets.scrollBarThumb);
+		DC->setColor(NULL);
 
 		// adjust size for item painting
 		size = fillRect.h /* - 2*/;
@@ -3993,6 +3994,9 @@ void Item_Init(itemDef_t *item)
 
 	// default hotkey to -1
 	item->hotkey = -1;
+
+	Vector4Set(item->scrollColor, 1, 1, 1, 1);
+	Vector4Set(item->sliderColor, 1, 1, 1, 1);
 
 	Window_Init(&item->window);
 }

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -2132,6 +2132,54 @@ qboolean ItemParse_voteFlag(itemDef_t *item, int handle)
 	return(PC_Int_Parse(handle, &item->voteFlag));
 }
 
+/**
+* @brief ItemParse_scrollColor
+* @param[in,out] item
+* @param[in] handle
+* @return
+*/
+qboolean ItemParse_scrollColor(itemDef_t *item, int handle)
+{
+	int   i;
+	float f = 0.0f;
+
+	for (i = 0; i < 4; i++)
+	{
+		if (!PC_Float_Parse(handle, &f))
+		{
+			return qfalse;
+		}
+
+		item->scrollColor[i] = f;
+	}
+
+	return qtrue;
+}
+
+/**
+* @brief ItemParse_sliderColor
+* @param[in,out] item
+* @param[in] handle
+* @return
+*/
+qboolean ItemParse_sliderColor(itemDef_t *item, int handle)
+{
+	int   i;
+	float f = 0.0f;
+
+	for (i = 0; i < 4; i++)
+	{
+		if (!PC_Float_Parse(handle, &f))
+		{
+			return qfalse;
+		}
+
+		item->sliderColor[i] = f;
+	}
+
+	return qtrue;
+}
+
 keywordHash_t itemParseKeywords[] =
 {
 	{ "accept",            ItemParse_accept,            NULL },
@@ -2219,6 +2267,8 @@ keywordHash_t itemParseKeywords[] =
 	{ "voteFlag",          ItemParse_voteFlag,          NULL }, // vote check
 	{ "wrapped",           ItemParse_wrapped,           NULL },
 	{ "bitflag",           ItemParse_bitflag,           NULL },
+	{ "scrollcolor",       ItemParse_scrollColor,       NULL },
+	{ "slidercolor",       ItemParse_sliderColor,       NULL },
 	{ NULL,                NULL,                        NULL }
 };
 

--- a/src/ui/ui_script.c
+++ b/src/ui/ui_script.c
@@ -183,6 +183,14 @@ void Script_SetItemColor(itemDef_t *item, qboolean *bAbort, char **args)
 				{
 					out = &item2->window.borderColor;
 				}
+				else if (Q_stricmp(name, "scrollcolor") == 0)
+				{
+					out = &item2->scrollColor;
+				}
+				else if (Q_stricmp(name, "slidercolor") == 0)
+				{
+					out = &item2->sliderColor;
+				}
 
 				if (out)
 				{
@@ -1351,6 +1359,42 @@ void Script_ToggleCvarBit(itemDef_t *item, qboolean *bAbort, char **args)
 }
 
 /**
+* @brief Script_SetTextStyle
+* @param[in] item
+* @param bAbort - unused
+* @param[in] args
+*/
+void Script_SetTextStyle(itemDef_t *item, qboolean *bAbort, char **args)
+{
+	const char *itemname = NULL;
+
+	// expecting type of color to set and 4 args for the color
+	if (String_Parse(args, &itemname))
+	{
+		itemDef_t *item2;
+		vec4_t    color;
+		vec4_t    *out;
+		int       j, i, style;
+		int       count = Menu_ItemsMatchingGroup(item->parent, itemname);
+
+		if (!Int_Parse(args, &style))
+		{
+			return;
+		}
+
+		for (j = 0; j < count; j++)
+		{
+			item2 = Menu_GetMatchingItemByNumber(item->parent, j, itemname);
+
+			if (item2 != NULL)
+			{
+				item2->textStyle = style;
+			}
+		}
+	}
+}
+
+/**
  * @brief Script_Skip
  * @param item - unused
  * @param bAbort - unused
@@ -1406,6 +1450,7 @@ commandDef_t commandList[] =
 	{ "abort",              &Script_Abort              },
 	{ "getclipboard",       &Script_GetClipboard       },
 	{ "togglecvarbit",      &Script_ToggleCvarBit      },
+	{ "settextstyle",       &Script_SetTextStyle       },
 	{ "none",               &Script_Skip               }, // skip execution (used as a placeholder)
 };
 

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -349,6 +349,9 @@ typedef struct itemDef_s
 
 	/// ETL: checkbox for bitflags in an integer cvar. The value it has is the bitvalue (1,2,4,8 etc)
 	int bitflag;
+
+	vec4_t scrollColor;
+	vec4_t sliderColor;
 } itemDef_t;
 
 /**


### PR DESCRIPTION
Added next itemDef directives:
* `scrollcolor` - blends color with scrollbar images
* `slidercolor` - blends color with slider images

Added event command `settextstyle` to change text style of an item when some event occurs.

Added next global defines in ui:
* `__WINDOW_WIDTH` - contains adjusted virtual window width
* `__WINDOW_HEIGHT` - contains virtual window height

These can be used to position elements from the right side of the window. (useful for widescreen windows)

Fixed widescreen support for vanilla clients in ui and cgame.