### PR TITLE
qagame: add geoip privacy option

### DIFF
--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8659,6 +8659,7 @@ cvarTable_t cvarTable[] =
 	{ NULL,                             "cg_locations",                        "3",                          CVAR_ARCHIVE,                   0 },
 
 	{ &ui_serverBrowserSettings,        "ui_serverBrowserSettings",            "0",                          CVAR_INIT,                      0 },
+	{ NULL,                             "cg_allowGeoIP",                       "1",                          CVAR_ARCHIVE | CVAR_USERINFO,   0 },
 };
 
 const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);


### PR DESCRIPTION
* clients can now toggle geolocation sharing using `cg_allowGeoIP`
refs #1179