### PR TITLE
qcommon: fix potential buffer overflow in COM_StripFilename

### DIFF
--- a/src/cgame/cg_sound.c
+++ b/src/cgame/cg_sound.c
@@ -1327,7 +1327,7 @@ qboolean CG_SpeakerEditor_NoiseEdit_KeyDown(panel_button_t *button, int key)
 			int  i, numfiles, filelen;
 			char *fileptr;
 
-			COM_StripFilename(button->text, dirname);
+			COM_StripFilename(button->text, dirname, sizeof(dirname));
 			Q_strncpyz(filename, COM_SkipPath(button->text), sizeof(filename));
 
 			if (!Q_stricmp(button->text, dirname))

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -81,17 +81,16 @@ void COM_FixPath(char *pathname)
  */
 char *COM_SkipPath(char *pathname)
 {
-	char *last = pathname;
+	char *last = strrchr(pathname, '/');
 
-	while (*pathname)
+	if (last)
 	{
-		if (*pathname == '/')
-		{
-			last = pathname + 1;
-		}
-		pathname++;
+		return last + 1;
 	}
-	return last;
+	else
+	{
+		return pathname;
+	}
 }
 
 /**

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -166,11 +166,11 @@ qboolean COM_CompareExtension(const char *in, const char *ext)
  * @param[in] in
  * @param[out] out
  */
-void COM_StripFilename(const char *in, char *out)
+void COM_StripFilename(const char *in, char *out, size_t outsize)
 {
 	char *end;
 
-	Q_strncpyz(out, in, strlen(in) + 1);
+	Q_strncpyz(out, in, outsize);
 	end  = COM_SkipPath(out);
 	*end = 0;
 }

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -610,7 +610,7 @@ void COM_FixPath(char *pathname);
 const char *COM_GetExtension(const char *name);
 void COM_StripExtension(const char *in, char *out, int destsize);
 qboolean COM_CompareExtension(const char *in, const char *ext);
-void COM_StripFilename(const char *in, char *out);
+void COM_StripFilename(const char *in, char *out, size_t outsize);
 
 void COM_DefaultExtension(char *path, size_t maxSize, const char *extension);
 


### PR DESCRIPTION
Fixes a potential buffer overflow and a compilation warning (`warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]`).
The COM_StripFilename function is only used once on a `MAX_QPATH` sized char array.
Also saw that Q_strncpyz function uses strncpy with len-1 and ensures a NUL at len-1 (so it is safe).