### PR TITLE
sys, OSX: Try to get out of OSX' app translocation. Or show installat…

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1035,6 +1035,17 @@ int main(int argc, char **argv)
 	{
 		char     parentdir[1024];
 		CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+		int quarantine_status = 0;
+
+		quarantine_status = needsOSXQuarantineFix();
+		if(quarantine_status == 1) {
+			//app restarts itself under the right path
+			Sys_Exit(EXIT_SUCCESS);
+		} else if (quarantine_status >=2) {
+			Sys_Dialog(DT_ERROR, "An error occured while removing the app quarantine flag automatically. Please read the installation instructions on removing the app quarantine on the ET Legacy wiki:\r\n\r\nhttps://dev.etlegacy.com/projects/etlegacy/wiki/Mac_OS_X", "Can't remove app quarantine");
+			Sys_Exit(EXIT_FAILURE);
+		}
+
 		if (!url)
 		{
 			Sys_Dialog(DT_ERROR, "A CFURL for the app bundle could not be found.", "Can't set Sys_SetBinaryPath");

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1038,10 +1038,19 @@ int main(int argc, char **argv)
 		int quarantine_status = 0;
 
 		quarantine_status = needsOSXQuarantineFix();
-		if(quarantine_status == 1) {
+		if(quarantine_status == 1)
+		{
 			//app restarts itself under the right path
 			Sys_Exit(EXIT_SUCCESS);
-		} else if (quarantine_status >=2) {
+		}
+		else if (quarantine_status == 4)
+		{
+			//user canceled the dialog box
+			Sys_Dialog(DT_ERROR, "Running ET Legacy with enabled App Translocation isn't possible. Please remove the quarantine flag by using the following command in the terminal and restart the game:\r\n\r\nxattr -cr /Applications/ET\\ Legacy/", "App Translocation detected");
+			Sys_Exit(EXIT_FAILURE);
+		}
+		else if (quarantine_status >= 2)
+		{
 			Sys_Dialog(DT_ERROR, "An error occured while removing the app quarantine flag automatically. Please read the installation instructions on removing the app quarantine on the ET Legacy wiki:\r\n\r\nhttps://dev.etlegacy.com/projects/etlegacy/wiki/Mac_OS_X", "Can't remove app quarantine");
 			Sys_Exit(EXIT_FAILURE);
 		}

--- a/src/sys/sys_osx.m
+++ b/src/sys/sys_osx.m
@@ -121,16 +121,19 @@ const char *OSX_ApplicationSupportPath()
  */
 bool IsTranslocatedURL(CFURLRef currentURL, CFURLRef *originalURL)
 {
-	if (currentURL == NULL) {
+	if (currentURL == NULL)
+    {
 		return false;
 	}
 
-	if (floor(NSAppKitVersionNumber) <= 1404) {
+	if (floor(NSAppKitVersionNumber) <= 1404)
+    {
 		return false;
 	}
 
 	void *handle = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_LAZY);
-	if (handle == NULL) {
+	if (handle == NULL)
+    {
 		return false;
 	}
 
@@ -138,13 +141,18 @@ bool IsTranslocatedURL(CFURLRef currentURL, CFURLRef *originalURL)
 
 	Boolean (*mySecTranslocateIsTranslocatedURL)(CFURLRef path, bool *isTranslocated, CFErrorRef * __nullable error);
 	mySecTranslocateIsTranslocatedURL = dlsym(handle, "SecTranslocateIsTranslocatedURL");
-	if (mySecTranslocateIsTranslocatedURL != NULL) {
-		if (mySecTranslocateIsTranslocatedURL(currentURL, &isTranslocated, NULL)) {
-			if (isTranslocated) {
-				if (originalURL != NULL) {
+	if (mySecTranslocateIsTranslocatedURL != NULL)
+    {
+		if (mySecTranslocateIsTranslocatedURL(currentURL, &isTranslocated, NULL))
+        {
+			if (isTranslocated)
+            {
+				if (originalURL != NULL)
+                {
 					CFURLRef __nullable (*mySecTranslocateCreateOriginalPathForURL)(CFURLRef translocatedPath, CFErrorRef * __nullable error);
 					mySecTranslocateCreateOriginalPathForURL = dlsym(handle, "SecTranslocateCreateOriginalPathForURL");
-					if (mySecTranslocateCreateOriginalPathForURL != NULL) {
+					if (mySecTranslocateCreateOriginalPathForURL != NULL)
+                    {
 						*originalURL = mySecTranslocateCreateOriginalPathForURL((CFURLRef)currentURL, NULL);
 					} else {
 						*originalURL = NULL;
@@ -163,8 +171,10 @@ bool IsTranslocatedURL(CFURLRef currentURL, CFURLRef *originalURL)
  * @brief Check for OSX Quarantine, remove the attributes und restart the app
  * @return int: 0 = no action required, 1 = relaunch after dequarantine, >=2 = error, show modal
  */
-int needsOSXQuarantineFix() {
+int needsOSXQuarantineFix()
+{
     bool isQuarantined;
+    bool dialogReturn;
     int taskRetVal;
     NSURL *appPath = [NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
     NSURL *newPath = nil;
@@ -172,25 +182,49 @@ int needsOSXQuarantineFix() {
     //does the app run in a translocated path?
     isQuarantined = IsTranslocatedURL((CFURLRef) appPath, &newPath);
 
-    if(isQuarantined) {
-        //remove quarantine flag
-        @try {
-            NSTask *xattrTask = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/xattr" arguments:@[@"-cr", (NSURL*)newPath.path]];
-            [xattrTask waitUntilExit];
-            taskRetVal = xattrTask.terminationStatus;
-        } @catch (NSException *exception) {
-            return 2;
-        }
+    if(isQuarantined)
+	{
 
-        //relaunch, using 'open'
-        @try {
-            [NSTask launchedTaskWithLaunchPath:@"/usr/bin/open" arguments:@[@"-n", @"-a", newPath.path]];
-        } @catch (NSException *exception) {
-            return 3;
-        }
-        //shutdown this instance
-        return 1;
-    } else {
-        return 0;
-    }
+		//ask user if we should fix it programmatically
+		dialogReturn = Sys_Dialog(DT_YES_NO, "The game runs in a hidden folder, to prevent possible dangerous apps. As this prevents loading the game files, a command needs to be executed to run the game from it's original path.\r\n\r\nShould the following command be executed now?\r\n\r\n/usr/bin/xattr -cr etl.app", "App Translocation detected");
+		if(dialogReturn == DR_YES)
+		{
+			//remove quarantine flag
+			@try
+			{
+				NSTask *xattrTask = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/xattr" arguments:@[@"-cr", (NSURL*)newPath.path]];
+				[xattrTask waitUntilExit];
+				taskRetVal = xattrTask.terminationStatus;
+				if(taskRetVal!=0)
+				{
+					char retstr[410];
+					snprintf(retstr, 400, "xattr error return value: %d", taskRetVal);
+					Sys_Dialog(DT_ERROR, retstr, "Can't remove app quarantine");
+					return 5;
+				}
+			}
+			@catch (NSException *exception)
+			{
+				Sys_Dialog(DT_ERROR, [exception.reason UTF8String], "Can't remove app quarantine");
+				return 2;
+			}
+
+			//relaunch, using 'open'
+			@try
+			{
+				[NSTask launchedTaskWithLaunchPath:@"/usr/bin/open" arguments:@[@"-n", @"-a", newPath.path]];
+			}
+			@catch (NSException *exception)
+			{
+				return 3;
+			}
+
+			//shutdown this instance
+			return 1;
+		}
+
+		return 4;
+	} else {
+		return 0;
+	}
 }


### PR DESCRIPTION
…ion link to the wiki, if an error occurs

Get the game out of OSX' quarantine/app translocation ("/private/var/folders..."), by removing the quarantine flag programmatically and relaunching itself. If this fails for whatever reason, show a modal box with the installation instructions wiki link.
The prevents (new) users from getting error messages on first installation or major client updates, as well as using the shell to remove the quarantine flag by hand.

Error modal looks like this:
<img width="422" alt="modal" src="https://user-images.githubusercontent.com/5468685/52901305-2bf04200-3202-11e9-95d8-a7e69bd1f796.png">
