### PR TITLE
Consistently define "x86_64" ARCH_STRING and never "amd64".

### DIFF
--- a/src/qcommon/q_platform.h
+++ b/src/qcommon/q_platform.h
@@ -260,7 +260,7 @@
 #elif defined __amd64__
 #undef idx64
 #define idx64 1
-#define ARCH_STRING "amd64"
+#define ARCH_STRING "x86_64"
 #elif defined __axp__
 #define ARCH_STRING "alpha"
 #endif


### PR DESCRIPTION
The CMake script will always produce internal libraries containing the string "x86_64" and never "amd64", so make sure the game engine always looks for libraries with "x86_64" in the filename.