### PR TITLE
game: Option to disable rifle grenades #1273

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -39,6 +39,7 @@
 
 #ifdef GAMEDLL
 extern vmCvar_t g_developer;
+extern vmCvar_t g_riflegrenades;
 #endif
 
 // *INDENT-OFF*
@@ -2572,6 +2573,18 @@ qboolean BG_AddMagicAmmo(playerState_t *ps, int *skill, team_t teamNum, int numO
 	{
 		if (GetWeaponTableData(weapon)->useAmmo)
 		{
+			#ifdef GAMEDLL
+			if (g_riflegrenades.integer == 0)
+			{
+				switch (weapon)
+				{
+					case WP_GPG40:
+					case WP_M7:
+						continue;
+				}
+			}
+			#endif
+
 			int      maxAmmo;
 			weapon_t clip;
 

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1089,6 +1089,16 @@ static void AddExtraSpawnAmmo(gclient_t *client, weapon_t weaponNum)
  */
 void AddWeaponToPlayer(gclient_t *client, weapon_t weapon, int ammo, int ammoclip, qboolean setcurrent)
 {
+	if (g_riflegrenades.integer == 0)
+	{
+		switch (weapon)
+		{
+			case WP_GPG40:
+			case WP_M7:
+				return;
+		}
+	}
+
 	COM_BitSet(client->ps.weapons, weapon);
 	client->ps.ammoclip[GetWeaponTableData(weapon)->clipIndex] = ammoclip;
 	client->ps.ammo[GetWeaponTableData(weapon)->ammoIndex]    += ammo;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2074,6 +2074,7 @@ extern vmCvar_t g_multiview;
 #define STICKYCHARGE_SELFKILL 1 // keep charge after selfkill, mortal self damage, teamkill, mortal world damage
 #define STICKYCHARGE_ANYDEATH 2 // keep charge after any death (for eg. death by enemy)
 extern vmCvar_t g_stickyCharge;
+extern vmCvar_t g_riflegrenades;
 
 /**
  * @struct GeoIPTag

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -349,6 +349,7 @@ vmCvar_t g_multiview; // 0 - off, other - enabled
 #endif
 
 vmCvar_t g_stickyCharge;
+vmCvar_t g_riflegrenades;	// b_riflegrenades functionality from ETPro
 
 cvarTable_t gameCvarTable[] =
 {
@@ -635,6 +636,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_multiview,                         "g_multiview",                         "0",                          CVAR_LATCH | CVAR_ARCHIVE,                       0, qfalse, qfalse },
 #endif
 	{ &g_stickyCharge,                      "g_stickyCharge",                      "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
+	{ &g_riflegrenades,                     "g_riflegrenades",                     "1",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 };
 
 /**


### PR DESCRIPTION
https://dev.etlegacy.com/issues/1273

g_riflegrenades = 1 is default. 0 disables them for both teams, while leaving the rifles themselves available.