### PR TITLE
Use cmake builtins to figure out if we should link against a libdl

### DIFF
--- a/cmake/ETLPlatform.cmake
+++ b/cmake/ETLPlatform.cmake
@@ -87,7 +87,7 @@ if(UNIX)
 		set(LIB_SUFFIX "_mac")
 		set(CMAKE_SHARED_MODULE_SUFFIX "")
 	else()
-		set(OS_LIBRARIES dl m rt pthread)
+		set(OS_LIBRARIES ${CMAKE_DL_LIBS} m rt pthread)
 		set(LIB_SUFFIX ".mp.")
 	endif()
 


### PR DESCRIPTION
Not all OSes ship it, and this means the logic can be used for
operating systems that don't ship libdl (netbsd, openbsd...)