### PR TITLE
mod: fix spawn pt have bad player count, refs #506

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1847,6 +1847,24 @@ static void CG_PrintObjectiveInfo_f(void)
 	CG_Printf("^2%i from %i objectives defined\n", i, MAX_OID_TRIGGERS);
 }
 
+static void CG_ListSpawnPoints_f()
+{
+	int i;
+	CG_Printf("^2Spawn Points\n");
+	for (i = 0; i < cg.spawnCount; i++)
+	{
+		// inactive
+		if (cg.spawnTeams[i] & 256)
+		{
+			CG_Printf("^9[%2i] %s %-26s\n", i, ((cg.spawnTeams[i] & 0xF) == TEAM_AXIS) ? "X" : "A", cg.spawnPoints[i]);
+		}
+		else
+		{
+			CG_Printf("^7[^2%2i^7] %s ^o%-26s\n", i, (cg.spawnTeams[i] == TEAM_AXIS) ? "^1X" : "^4A", cg.spawnPoints[i]);
+		}
+	}
+}
+
 static consoleCommand_t commands[] =
 {
 	{ "testgun",             CG_TestGun_f              },
@@ -1965,7 +1983,8 @@ static consoleCommand_t commands[] =
 #endif
 	// objective info list for mappers/scripters (and players? - we might extend it)
 	{ "oinfo",               CG_PrintObjectiveInfo_f   },
-	{ "resetmaxspeed",       CG_ResetMaxSpeed_f        }
+	{ "resetmaxspeed",       CG_ResetMaxSpeed_f        },
+	{ "listspawnpt",         CG_ListSpawnPoints_f      }
 };
 
 /**

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -642,7 +642,7 @@ void CopyToBodyQue(gentity_t *ent)
 	BODY_TEAM(body)      = ent->client->sess.sessionTeam;
 	BODY_CLASS(body)     = ent->client->sess.playerType;
 	BODY_CHARACTER(body) = ent->client->pers.characterIndex;
-	BODY_VALUE(body)     = 0;
+	BODY_VALUE(body) = 0;
 
 	//if ( ent->client->ps.eFlags & EF_PANTSED ){
 	//	body->s.time2 =	1;
@@ -2738,8 +2738,6 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	int                savedTeam;
 	int                savedDeathTime;
 
-	G_UpdateSpawnCounts();
-
 	client->pers.lastSpawnTime            = level.time;
 	client->pers.lastBattleSenseBonusTime = level.timeCurrent;
 	client->pers.lastHQMineReportTime     = level.timeCurrent;
@@ -2770,6 +2768,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	}
 	else
 	{
+		G_UpdateSpawnPointStatePlayerCounts();
 		// let's just be sure it does the right thing at all times. (well maybe not the right thing, but at least not the bad thing!)
 		//if( client->sess.sessionTeam == TEAM_SPECTATOR || client->sess.sessionTeam == TEAM_FREE ) {
 		if (client->sess.sessionTeam != TEAM_AXIS && client->sess.sessionTeam != TEAM_ALLIES)
@@ -2778,7 +2777,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 		}
 		else
 		{
-			spawnPoint = SelectCTFSpawnPoint(client->sess.sessionTeam, client->pers.teamState.state, spawn_origin, spawn_angles, client->sess.spawnObjectiveIndex);
+			spawnPoint = SelectCTFSpawnPoint(client->sess.sessionTeam, client->pers.teamState.state, spawn_origin, spawn_angles, client->sess.userSpawnPointValue);
 		}
 	}
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -632,7 +632,8 @@ typedef struct
 	int playerType;                                     ///< for GT_WOLF
 	weapon_t playerWeapon;                              ///< for GT_WOLF
 	weapon_t playerWeapon2;                             ///< secondary weapon
-	int spawnObjectiveIndex;                            ///< index of objective to spawn nearest to (returned from UI)
+	int userSpawnPointValue;                            ///< index of objective to spawn nearest to (returned from UI)
+	int resolvedSpawnPointIndex;                        ///< most possible objective to spawn nearest to
 	int latchPlayerType;                                ///< for GT_WOLF not archived
 	weapon_t latchPlayerWeapon;                         ///< for GT_WOLF not archived
 	weapon_t latchPlayerWeapon2;                        ///< secondary weapon
@@ -1113,6 +1114,15 @@ typedef struct database_s
 } database_t;
 #endif
 
+typedef struct spawnPointState_s
+{
+	vec3_t origin;
+	team_t team;
+	int playerCount;
+	int isActive;
+	char description[128];
+} spawnPointState_t;
+
 /**
  * @struct level_locals_s
  * @typedef level_locals_t
@@ -1182,8 +1192,8 @@ typedef struct level_locals_s
 	int bodyQueIndex;                           ///< dead bodies
 	gentity_t *bodyQue[BODY_QUEUE_SIZE];
 
-	vec3_t spawntargets[MAX_MULTI_SPAWNTARGETS];    ///< coordinates of spawn targets
-	int numspawntargets;                        ////< # spawntargets in this map
+	int numSpawnPoints;                        ////< number of spawn points in this map
+	spawnPointState_t spawnPointStates[MAX_MULTI_SPAWNTARGETS];
 
 	/// entity scripting
 	char *scriptEntity;
@@ -1681,7 +1691,6 @@ qboolean ReadyToConstruct(gentity_t *ent, gentity_t *constructible, qboolean upd
 // g_team.c
 qboolean OnSameTeam(gentity_t *ent1, gentity_t *ent2);
 //int Team_ClassForString(const char *string); // Unused
-void reset_numobjectives(void);
 
 // g_mem.c
 void *G_Alloc(unsigned int size);
@@ -2585,7 +2594,8 @@ void G_MakeReady(gentity_t *ent);
 void G_MakeUnready(gentity_t *ent);
 
 void SetPlayerSpawn(gentity_t *ent, int spawn, qboolean update);
-void G_UpdateSpawnCounts(void);
+void G_UpdateSpawnPointState(gentity_t *ent);
+void G_UpdateSpawnPointStatePlayerCounts();
 
 void G_SetConfigStringValue(int num, const char *key, const char *value);
 void G_GlobalClientEvent(entity_event_t event, int param, int client);

--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -1013,7 +1013,7 @@ static const gentity_field_t gclient_fields[] =
 	_et_gclient_addfield(sess.playerType,                   FIELD_INT,                 0),
 	_et_gclient_addfield(sess.playerWeapon,                 FIELD_INT,                 0),
 	_et_gclient_addfield(sess.playerWeapon2,                FIELD_INT,                 0),
-	_et_gclient_addfield(sess.spawnObjectiveIndex,          FIELD_INT,                 0),
+	_et_gclient_addfield(sess.userSpawnPointValue,          FIELD_INT,                 0),
 	_et_gclient_addfield(sess.latchPlayerType,              FIELD_INT,                 0),
 	_et_gclient_addfield(sess.latchPlayerWeapon,            FIELD_INT,                 0),
 	_et_gclient_addfield(sess.latchPlayerWeapon2,           FIELD_INT,                 0),

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -2330,7 +2330,8 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int legacyServer, in
 
 	for (i = 0; i < level.numConnectedClients; i++)
 	{
-		level.clients[level.sortedClients[i]].sess.spawnObjectiveIndex = 0;
+		level.clients[level.sortedClients[i]].sess.userSpawnPointValue     = 0;
+		level.clients[level.sortedClients[i]].sess.resolvedSpawnPointIndex = 0;
 	}
 
 	// init the anim scripting
@@ -2545,7 +2546,6 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int legacyServer, in
 	// Clear out spawn target config strings
 	trap_GetConfigstring(CS_MULTI_INFO, cs, sizeof(cs));
 	Info_SetValueForKey(cs, "s", "0"); // numspawntargets
-	reset_numobjectives();
 	trap_SetConfigstring(CS_MULTI_INFO, cs);
 
 	for (i = CS_MULTI_SPAWNTARGETS; i < CS_MULTI_SPAWNTARGETS + MAX_MULTI_SPAWNTARGETS; i++)

--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -212,7 +212,7 @@ qboolean G_ScriptAction_SetAutoSpawn(gentity_t *ent, char *params)
 
 	*pTeamAutoSpawn = tent->count - CS_MULTI_SPAWNTARGETS;
 
-	G_UpdateSpawnCounts();
+	G_UpdateSpawnPointStatePlayerCounts();
 
 	return qtrue;
 }
@@ -252,7 +252,7 @@ qboolean G_ScriptAction_ChangeModel(gentity_t *ent, char *params)
 qboolean G_ScriptAction_ShaderRemap(gentity_t *ent, char *params)
 {
 	char  *pString = params, *token;
-	float f        = level.time * 0.001f;
+	float f = level.time * 0.001f;
 	char  oldShader[MAX_QPATH];
 	char  newShader[MAX_QPATH];
 
@@ -2004,7 +2004,7 @@ qboolean G_ScriptAction_MusicPlay(gentity_t *ent, char *params)
  */
 qboolean G_ScriptAction_MusicStop(gentity_t *ent, char *params)
 {
-	char *pString    = params, *token;
+	char *pString = params, *token;
 	int  fadeoutTime = 0;
 
 	token = COM_ParseExt(&pString, qfalse);
@@ -2049,7 +2049,7 @@ qboolean G_ScriptAction_MusicQueue(gentity_t *ent, char *params)
  */
 qboolean G_ScriptAction_MusicFade(gentity_t *ent, char *params)
 {
-	char  *pString    = params, *token;
+	char  *pString = params, *token;
 	int   fadeoutTime = 0;
 	float targetVol   = 0.0;
 
@@ -2932,7 +2932,7 @@ qboolean G_ScriptAction_Print(gentity_t *ent, char *params)
 	// Default to printing whole string
 	char *printThis = params;
 
-	char *pString   = params, *token;
+	char *pString = params, *token;
 	int  printLevel = 0;
 
 	if (!params || !params[0])

--- a/src/game/g_session.c
+++ b/src/game/g_session.c
@@ -113,7 +113,7 @@ void G_WriteClientSessionData(gclient_t *client, qboolean restart)
 	       client->sess.ignoreClients[0],
 	       client->sess.ignoreClients[1],
 	       client->pers.enterTime,
-	       restart ? client->sess.spawnObjectiveIndex : 0,
+	       restart ? client->sess.userSpawnPointValue : 0,
 	       client->sess.uci
 	       );
 
@@ -322,7 +322,7 @@ void G_ReadSessionData(gclient_t *client)
 	       &client->sess.ignoreClients[0],
 	       &client->sess.ignoreClients[1],
 	       &client->pers.enterTime,
-	       &client->sess.spawnObjectiveIndex,
+	       &client->sess.userSpawnPointValue,
 	       &client->sess.uci
 	       );
 
@@ -415,7 +415,7 @@ void G_InitSessionData(gclient_t *client, const char *userinfo)
 	sess->latchPlayerWeapon = sess->playerWeapon = WP_NONE;
 	sess->latchPlayerWeapon2 = sess->playerWeapon2 = WP_NONE;
 
-	sess->spawnObjectiveIndex = 0;
+	sess->userSpawnPointValue = 0;
 
 	Com_Memset(sess->ignoreClients, 0, sizeof(sess->ignoreClients));
 

--- a/src/game/g_utils.c
+++ b/src/game/g_utils.c
@@ -1314,12 +1314,8 @@ void G_SetEntState(gentity_t *ent, entState_t state)
 
 		if (ent->s.eType == ET_WOLF_OBJECTIVE)
 		{
-			char cs[MAX_STRING_CHARS];
-
-			trap_GetConfigstring(ent->count, cs, sizeof(cs));
 			ent->count2 &= ~256;
-			Info_SetValueForKey(cs, "t", va("%i", ent->count2));
-			trap_SetConfigstring(ent->count, cs);
+			G_UpdateSpawnPointState(ent);
 		}
 
 		if (ent->s.eType != ET_COMMANDMAP_MARKER)
@@ -1463,12 +1459,8 @@ void G_SetEntState(gentity_t *ent, entState_t state)
 		}
 		else if (ent->s.eType == ET_WOLF_OBJECTIVE)
 		{
-			char cs[MAX_STRING_CHARS];
-
-			trap_GetConfigstring(ent->count, cs, sizeof(cs));
 			ent->count2 |= 256;
-			Info_SetValueForKey(cs, "t", va("%i", ent->count2));
-			trap_SetConfigstring(ent->count, cs);
+			G_UpdateSpawnPointState(ent);
 		}
 
 		if (ent->s.eType == ET_COMMANDMAP_MARKER)


### PR DESCRIPTION
* Fixed incorrect player counts at spawn points on the command map.
* Rewrote player counter and spawn point update code. Should be more reliable now. It handles both invalid auto spawns and player selected spawns, and tries to resolve to nearest available team spawn point.
* Added `listspawnpt` client command to print available map spawns.
* Added additional prints to `setspawnpt` command.
* Removed unnecessary stuff and function calls.