### PR TITLE
cgame: fix cg_drawGun 2, refs #1324

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3148,13 +3148,14 @@ void CG_AddViewWeapon(playerState_t *ps)
 		return;
 	}
 
-	// allow the gun to be completely removed (0)
-	// allow the gun to be completely removed but non-weapons, melee weapon, syringue and throwables including grenade (2)
+	// hide all gun models (0)
+	// draw all gun models (1)
+	// draw only melee weapon, syringe and pliers, and throwables (incl. grenades) (2)
 	if (!cg_drawGun.integer || (cg_drawGun.integer == 2
-	                            && GetWeaponTableData(cg.weaponSelect)->type
-	                            && !(GetWeaponTableData(cg.weaponSelect)->type & WEAPON_TYPE_GRENADE)
-	                            && !(GetWeaponTableData(cg.weaponSelect)->type & WEAPON_TYPE_MELEE)
-	                            && !(GetWeaponTableData(cg.weaponSelect)->type & WEAPON_TYPE_SYRINGUE)))
+	                            && GetWeaponTableData(ps->weapon)->type
+	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_GRENADE)
+	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_MELEE)
+	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_SYRINGUE)))
 	{
 		if ((cg.predictedPlayerState.eFlags & EF_FIRING) && !BG_PlayerMounted(cg.predictedPlayerState.eFlags))
 		{


### PR DESCRIPTION
In case you would die having drawable weapon selected (like knife or nade, etc), fire weapon would be drawn in limbo mode.