### PR TITLE
renderer: fix crash when main lod model is missing

### DIFF
--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -217,8 +217,8 @@ qboolean COM_BitCheck(const int array[], unsigned int bitNum)
 {
 	unsigned int i = bitNum / 32;
 	unsigned int bitmask;
-	bitNum = bitNum % 32;
-	bitmask= 1u << bitNum;
+	bitNum  = bitNum % 32;
+	bitmask = 1u << bitNum;
 	return ((array[i] & bitmask) != 0);
 }
 
@@ -231,8 +231,8 @@ void COM_BitSet(int array[], unsigned int bitNum)
 {
 	unsigned int i = bitNum / 32;
 	unsigned int bitmask;
-	bitNum = bitNum % 32;
-	bitmask= 1u << bitNum;
+	bitNum  = bitNum % 32;
+	bitmask = 1u << bitNum;
 
 	array[i] |= bitmask;
 }
@@ -246,8 +246,8 @@ void COM_BitClear(int array[], unsigned int bitNum)
 {
 	unsigned int i = bitNum / 32;
 	unsigned int bitmask;
-	bitNum = bitNum % 32;
-	bitmask= ~(1u << bitNum);
+	bitNum  = bitNum % 32;
+	bitmask = ~(1u << bitNum);
 
 	array[i] &= bitmask;
 }
@@ -286,14 +286,14 @@ short ShortNoSwap(short l)
  */
 int LongSwap(int l)
 {
-	/* is compiled to bswap on gcc/clang/msvc */	
+	/* is compiled to bswap on gcc/clang/msvc */
 	unsigned int tmp = l;
 	unsigned int b1  = (tmp & 0x000000ff) << 24;
 	unsigned int b2  = (tmp & 0x0000ff00) <<  8;
 	unsigned int b3  = (tmp & 0x00ff0000) >>  8;
 	unsigned int b4  = (tmp & 0xff000000) >> 24;
 
-	return ( b1 | b2 | b3 | b4);
+	return (b1 | b2 | b3 | b4);
 }
 
 /**
@@ -2668,4 +2668,23 @@ qboolean CompareIPNoPort(char const *ip1, char const *ip2)
 	{
 		return qfalse;
 	}
+}
+
+/**
+ * @brief Com_AnyOf returns first valid pointer from the set
+ * @param[in] ptr list of pointers
+ * @param[in] n pointer count
+ * @return first non-null pointer
+ */
+void *Com_AnyOf(void **ptr, int n)
+{
+	int i;
+	for (i = 0; i < n; i++)
+	{
+		if (ptr[i])
+		{
+			return ptr[i];
+		}
+	}
+	return NULL;
 }

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -402,8 +402,8 @@ typedef int clipHandle_t;
 
 /**
  * @def Check whether input value is present or not in given bitwise.
- */ 
-#define CHECKBITWISE(x, y) (((x) & (y)) == (y)) 
+ */
+#define CHECKBITWISE(x, y) (((x) & (y)) == (y))
 
 //#define   SND_NORMAL          0x000   ///< (default) Allow sound to be cut off only by the same sound on this channel
 #define     SND_OKTOCUT         0x001   ///< Allow sound to be cut off by any following sounds on this channel
@@ -605,6 +605,8 @@ qboolean Com_PowerOf2(int x);
 
 #define Com_ByteClamp(x) ((x < 0) ? 0 : (x > 255) ? 255 : x)
 #define Com_Clamp(min, max, value) ((value < min) ? min : (value > max) ? max : value)
+#define Com_Nelem(a) (int)(sizeof(a) / sizeof(a)[0])
+void *Com_AnyOf(void **ptr, int n);
 
 char *COM_SkipPath(char *pathname);
 void COM_FixPath(char *pathname);
@@ -1431,10 +1433,10 @@ typedef enum
 	ET_WOLF_OBJECTIVE,
 
 	ET_AIRSTRIKE_PLANE,
-    
+
 	ET_EVENTS                   ///< any of the EV_* events can be added freestanding
-                                ///< by setting eType to ET_EVENTS + eventNum
-                                ///< this avoids having to set eFlags and eventNum
+	                            ///< by setting eType to ET_EVENTS + eventNum
+	                            ///< this avoids having to set eFlags and eventNum
 } entityType_t;
 
 /**

--- a/src/renderer/tr_model.c
+++ b/src/renderer/tr_model.c
@@ -303,6 +303,18 @@ qhandle_t RE_RegisterModel(const char *name)
 
 			if (!buf)
 			{
+				if (lod == 0 && mod->numLods > 1)
+				{
+					if (mod->type == MOD_MESH)
+					{
+						mod->model.md3[0] = Com_AnyOf((void **)mod->model.md3, Com_Nelem(mod->model.md3));
+					}
+					else if (mod->type == MOD_MDC)
+					{
+						mod->model.mdc[0] = Com_AnyOf((void **)mod->model.mdc, Com_Nelem(mod->model.mdc));
+					}
+					Ren_Warning("RE_RegisterModel: found lods, but main model '%s' is missing\n", name);
+				}
 				continue;
 			}
 		}
@@ -823,8 +835,8 @@ static qboolean R_MDC_ConvertMD3(model_t *mod, int lod, const char *name)
 			{
 				// copy this baseFrame from the md3
 				Com_Memcpy((byte *)cSurf + cSurf->ofsXyzNormals + (sizeof(md3XyzNormal_t) * cSurf->numVerts * i),
-				       (byte *)surf + surf->ofsXyzNormals + (sizeof(md3XyzNormal_t) * cSurf->numVerts * f),
-				       sizeof(md3XyzNormal_t) * cSurf->numVerts);
+				           (byte *)surf + surf->ofsXyzNormals + (sizeof(md3XyzNormal_t) * cSurf->numVerts * f),
+				           sizeof(md3XyzNormal_t) * cSurf->numVerts);
 				i++;
 				frameCompFrames[f] = -1;
 				frameBaseFrames[f] = i - 1;
@@ -950,7 +962,7 @@ static qboolean R_LoadMDC(model_t *mod, int lod, void *buffer, const char *name)
 	// swap all the tags
 	if (LittleLong(1) != 1)
 	{
-        tag = ( mdcTag_t * )((byte *)mod->model.mdc[lod] + mod->model.mdc[lod]->ofsTags);
+		tag = ( mdcTag_t * )((byte *)mod->model.mdc[lod] + mod->model.mdc[lod]->ofsTags);
 
 		for (i = 0 ; i < mod->model.mdc[lod]->numTags * mod->model.mdc[lod]->numFrames ; i++, tag++)
 		{
@@ -1908,7 +1920,7 @@ void R_Modellist_f(void)
 	// not working right with new hunk
 	// if (tr.world)
 	// {
-	// 	ri.Printf(PRINT_ALL, "\n%8i : %s\n", tr.world->dataSize, tr.world->name);
+	//  ri.Printf(PRINT_ALL, "\n%8i : %s\n", tr.world->dataSize, tr.world->name);
 	// }
 
 }
@@ -2296,7 +2308,7 @@ void *R_Hunk_Alloc(int size)
 	//Ren_Print("R_Hunk_Alloc(%d)\n", size);
 
 	// round to cacheline
-	size = PAD(size,32);
+	size = PAD(size, 32);
 
 #ifdef _WIN32
 

--- a/src/renderer2/tr_model.c
+++ b/src/renderer2/tr_model.c
@@ -237,6 +237,14 @@ qhandle_t RE_RegisterModel(const char *name)
 			}
 			if (!buffer)
 			{
+				if (lod == 0 && mod->numLods > 1)
+				{
+					if (mod->type == MOD_MESH)
+					{
+						mod->mdv[0] = Com_AnyOf((void **)mod->mdv, Com_Nelem(mod->mdv));
+					}
+					Ren_Warning("RE_RegisterModel: found lods, but main model '%s' is missing\n", name);
+				}
 				continue;
 			}
 		}


### PR DESCRIPTION
In case lod models exist but main model is missing, `R_ComputeLOD` would attempt to access null pointer which leads to a crash. To fix this we are just finding first available lod model and referencing that as a main model.