### PR TITLE
general: fix engine crash on 64bit systems, refs #1351 #1211 #1089

### DIFF
--- a/src/botlib/l_memory.c
+++ b/src/botlib/l_memory.c
@@ -354,7 +354,7 @@ void *GetMemory(unsigned long size)
 	}
 	memid  = (unsigned long int *) ptr;
 	*memid = MEM_ID;
-	return (unsigned long int *) ((char *) ptr + sizeof(unsigned long int));
+	return (char *) ptr + sizeof(unsigned long int);
 }
 
 #ifdef MEMDEBUG
@@ -399,7 +399,7 @@ void *GetHunkMemory(unsigned long size)
 	}
 	memid  = (unsigned long int *) ptr;
 	*memid = HUNK_ID;
-	return (unsigned long int *) ((char *) ptr + sizeof(unsigned long int));
+	return (char *)ptr + sizeof(unsigned long int);
 }
 
 #ifdef MEMDEBUG

--- a/src/botlib/l_script.h
+++ b/src/botlib/l_script.h
@@ -175,8 +175,8 @@ typedef struct token_s
 	int type;                           ///< last read token type
 	int subtype;                        ///< last read token sub type
 #ifdef NUMBERVALUE
-	unsigned long int intvalue;         ///< integer value
-	long double floatvalue;             ///< floating point value
+	int intvalue;         ///< integer value
+	float floatvalue;             ///< floating point value
 #endif //NUMBERVALUE
 	char *whitespace_p;                 ///< start of white space before token
 	char *endwhitespace_p;              ///< start of white space before token


### PR DESCRIPTION
Engine was crashing on startup on 64 bit systems on Release builds.

It was happening due to SSE optimizations taking place, yielded by the
compiler on default settings (ETLegacy does not specify any optimization
flags by default). Most specifically the "movaps" instruction was failing
because it could not null several structure fields (in token_t) at once,
because it could not operate properly on Z_Malloc'ed memory block, as the
instruction requires a 16 byte boundary alignments, where Z_Malloc only does
4/8 byte paddings (depending on the system). The token_t alignment was 16 byte
due to the usage of "long double" type on "floatvalue" field, which is
extraordinarily big, even though on the 32bit systems it still occupies
12bytes, the struct alignment stays within 4 bytes, because the type is
non-atomic. The token_t "floatvalue" and "intvalue" now matching the
"pc_token_t" field types, as this makes more sense, since "pc_token_t" is the
structure used to receive "token_t" values on the mod side.

* fixed botlib token_t alignment, was breaking sse optimization (causing
the crash)
* shut some botlib warnings