### PR TITLE
sdl: fix com_minimized was not reset properly

### DIFF
--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -1271,6 +1271,7 @@ static void IN_ProcessEvents(void)
 			case SDL_WINDOWEVENT_MINIMIZED:
 				Cvar_SetValue("com_minimized", 1);
 				break;
+			case SDL_WINDOWEVENT_SHOWN:
 			case SDL_WINDOWEVENT_RESTORED:
 			case SDL_WINDOWEVENT_MAXIMIZED:
 				Cvar_SetValue("com_minimized", 0);


### PR DESCRIPTION
Due to the bug in SDL2 on X11 https://bugzilla.libsdl.org/show_bug.cgi?id=4821
the RESTORE event is not sent for X11 clients which broke the
unminimized state restoration in etlegacy, god knows when this is
going to be fixed, but for now just use SHOWN event, which is basically the
same thing.