### PR TITLE
sys, OSX: de-quarantine the whole directory, instead of just etl.app

### DIFF
--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1015,7 +1015,6 @@ int main(int argc, char **argv)
 		else if (quarantine_status == 4)
 		{
 			//user canceled the dialog box
-			Sys_Dialog(DT_ERROR, "Running ET Legacy with enabled App Translocation isn't possible. Please remove the quarantine flag by using the following command in the terminal and restart the game:\r\n\r\nxattr -cr <insert-path-of-etlegacy>\r\n\r\nFor more information please go to:\r\n\r\nhttps://dev.etlegacy.com/projects/etlegacy/wiki/Mac_OS_X", "App Translocation detected");
 			Sys_Exit(EXIT_FAILURE);
 		}
 		else if (quarantine_status >= 2)

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -1015,7 +1015,7 @@ int main(int argc, char **argv)
 		else if (quarantine_status == 4)
 		{
 			//user canceled the dialog box
-			Sys_Dialog(DT_ERROR, "Running ET Legacy with enabled App Translocation isn't possible. Please remove the quarantine flag by using the following command in the terminal and restart the game:\r\n\r\nxattr -cr /Applications/ET\\ Legacy/", "App Translocation detected");
+			Sys_Dialog(DT_ERROR, "Running ET Legacy with enabled App Translocation isn't possible. Please remove the quarantine flag by using the following command in the terminal and restart the game:\r\n\r\nxattr -cr <insert-path-of-etlegacy>\r\n\r\nFor more information please go to:\r\n\r\nhttps://dev.etlegacy.com/projects/etlegacy/wiki/Mac_OS_X", "App Translocation detected");
 			Sys_Exit(EXIT_FAILURE);
 		}
 		else if (quarantine_status >= 2)

--- a/src/sys/sys_osx.m
+++ b/src/sys/sys_osx.m
@@ -236,8 +236,14 @@ int needsOSXQuarantineFix()
 			//shutdown this instance
 			return 1;
 		}
-
-		return 4;
+		else
+		{
+			NSMutableString *errortext = [NSMutableString stringWithString: @"Running ET Legacy with enabled App Translocation isn't possible. Please remove the quarantine flag by using the following command in the terminal and restart the game:\r\n\r\nxattr -cr "];
+			[errortext appendString:tempPath];
+			[errortext appendString:@"\r\n\r\nFor more information please go to:\r\n\r\nhttps://dev.etlegacy.com/projects/etlegacy/wiki/Mac_OS_X"];
+			Sys_Dialog(DT_ERROR, [errortext UTF8String], "App Translocation detected");
+			return 4;
+		}
 	}
 	else
 	{

--- a/src/sys/sys_osx.m
+++ b/src/sys/sys_osx.m
@@ -188,19 +188,19 @@ int needsOSXQuarantineFix()
 
 	if (isQuarantined)
 	{
-		//strip etl.app from string, to get the directory
+		// strip etl.app from string to get the directory
 		NSMutableString *tempPath = [NSMutableString stringWithString: [newPath.path stringByReplacingOccurrencesOfString:@"/etl.app" withString:@""]];
 		NSString *tempPathBin = @"/etl.app";
 
 		// assemble dialog text
-		NSMutableString *permissiontext = [NSMutableString stringWithString: @"The game runs in a hidden folder, to prevent possible dangerous apps. As this prevents loading the game files, a command needs to be executed to run the game from it's original path.\r\n\r\nShould the following command be executed now?\r\n\r\n/usr/bin/xattr -cr "];
+		NSMutableString *permissiontext = [NSMutableString stringWithString: @"The game runs in a hidden folder, to prevent possible dangerous apps. As this prevents loading the game files, a command needs to be executed to run the game from its original path.\r\n\r\nShould the following command be executed now?\r\n\r\n/usr/bin/xattr -cr "];
 		[permissiontext appendString:tempPath];
 
-		//ask user if we should fix it programmatically
+		// ask user if we should fix it programmatically
 		dialogReturn = Sys_Dialog(DT_YES_NO, [permissiontext UTF8String], "App Translocation detected");
 		if (dialogReturn == DR_YES)
 		{
-			//remove quarantine flag
+			// remove quarantine flag
 			@try
 			{
 				NSTask *xattrTask = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/xattr" arguments:@[@"-cr", (NSURL *)tempPath]];
@@ -220,7 +220,7 @@ int needsOSXQuarantineFix()
 				return 2;
 			}
 
-			//relaunch, using 'open'
+			// relaunch, using 'open'
 			@try
 			{
 				// readd "/etl.app" to path


### PR DESCRIPTION
macOS Catalina seem to block access to renderer and mod, so expanding the app translocation check and de-quarantine command to the whole directory, instead of just the etl.app.