### PR TITLE
cgame: add bp command, refs #233 #1198

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -741,7 +741,7 @@ static void CG_DrawCenterString(void)
 	char  *start, *end;
 	int   len;
 	char  currentColor[3] = S_COLOR_WHITE;
-	char  nextColor[3] = { 0, 0, 0 };
+	char  nextColor[3]    = { 0, 0, 0 };
 	int   x, y, w;
 	float *color;
 
@@ -889,10 +889,10 @@ static void CG_DrawScopedReticle(void)
  */
 static void CG_DrawMortarReticle(void)
 {
-	vec4_t   color = { 1.f, 1.f, 1.f, .5f };
-	vec4_t   color_back = { 0.f, 0.f, 0.f, .25f };
-	vec4_t   color_extends = { .77f, .73f, .1f, 1.f };
-	vec4_t   color_lastfire = { .77f, .1f, .1f, 1.f };
+	vec4_t   color             = { 1.f, 1.f, 1.f, .5f };
+	vec4_t   color_back        = { 0.f, 0.f, 0.f, .25f };
+	vec4_t   color_extends     = { .77f, .73f, .1f, 1.f };
+	vec4_t   color_lastfire    = { .77f, .1f, .1f, 1.f };
 	vec4_t   color_firerequest = { 1.f, 1.f, 1.f, 1.f };
 	float    offset, localOffset;
 	int      i, min, majorOffset, val, printval, fadeTime, requestFadeTime;
@@ -1266,9 +1266,9 @@ static void CG_DrawCrosshair(void)
             }
             else */if (
 #ifdef FEATURE_MULTIVIEW
-				cg.mvTotalClients < 1 ||
+			    cg.mvTotalClients < 1 ||
 #endif
-				cg.snap->ps.stats[STAT_HEALTH] > 0)
+			    cg.snap->ps.stats[STAT_HEALTH] > 0)
 			{
 				CG_DrawScopedReticle();
 			}
@@ -2431,7 +2431,7 @@ static void CG_DrawSpectatorMessage(void)
 {
 	const char *str, *str2;
 	static int lastconfigGet = 0;
-	float      fontScale = cg_fontScaleSP.value;
+	float      fontScale     = cg_fontScaleSP.value;
 	int        y, charHeight;
 
 	charHeight = CG_Text_Height_Ext("A", fontScale, 0, &cgs.media.limboFont2);
@@ -2995,9 +2995,9 @@ static void CG_DrawFlashFade(void)
 	{
 		if (
 #ifdef FEATURE_MULTIVIEW
-			cg.mvTotalClients < 1 &&
+		    cg.mvTotalClients < 1 &&
 #endif
-			cg.snap->ps.powerups[PW_BLACKOUT] > 0)
+		    cg.snap->ps.powerups[PW_BLACKOUT] > 0)
 		{
 			trap_Cvar_Set("ui_blackout", va("%d", cg.snap->ps.powerups[PW_BLACKOUT]));
 		}
@@ -3235,7 +3235,7 @@ static void CG_DrawObjectiveInfo(void)
 	char   *start, *end;
 	int    len;
 	char   currentColor[3] = S_COLOR_WHITE;
-	char   nextColor[3] = { 0, 0, 0 };
+	char   nextColor[3]    = { 0, 0, 0 };
 	int    x, y, w;
 	int    x1, y1, x2, y2;
 	float  *color;
@@ -3596,6 +3596,33 @@ void CG_DrawOnScreenLabels(void)
 }
 
 /**
+ * @brief CG_DrawBannerPrint
+ */
+static void CG_DrawBannerPrint(void)
+{
+	float *color;
+	int   lineHeight;
+	int   bptime = cg_bannerPrintTime.integer;
+
+	if ((cg_drawBannerPrint.integer <= 0) || (bptime <= 0) || !cg.bannerPrintTime)
+	{
+		return;
+	}
+
+	color = CG_FadeColor(cg.bannerPrintTime, bptime);
+
+	if (!color)
+	{
+		cg.bannerPrintTime = 0;
+		return;
+	}
+
+	lineHeight = ((float)CG_Text_Height_Ext("M", 0.25, 0, &cgs.media.limboFont1) * 1.5f);
+
+	CG_DrawMultilineText(Ccg_WideX(320), 20, 0.25, 0.25, color, cg.bannerPrint, lineHeight, 0, 0, ITEM_TEXTSTYLE_SHADOWED, ITEM_ALIGN_CENTER, &cgs.media.limboFont1);
+}
+
+/**
  * @brief CG_Draw2D
  */
 static void CG_Draw2D(void)
@@ -3684,6 +3711,8 @@ static void CG_Draw2D(void)
 	// don't draw center string if scoreboard is up
 	if (!CG_DrawScoreboard())
 	{
+		CG_DrawBannerPrint();
+
 		CG_SetHud();
 
 #ifdef FEATURE_EDV

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1400,6 +1400,10 @@ typedef struct
 #ifdef FEATURE_PRESTIGE
 	int prestige[MAX_CLIENTS];
 #endif
+
+	// banner printing
+	int bannerPrintTime;
+	char bannerPrint[1024];
 } cg_t;
 
 #define MAX_LOCKER_DEBRIS   5
@@ -2648,6 +2652,8 @@ extern vmCvar_t cg_quickchat;
 extern vmCvar_t cg_drawspeed;
 
 extern vmCvar_t cg_visualEffects;  ///< turn invisible (0) / visible (1) visual effect (i.e airstrike plane, debris ...)
+extern vmCvar_t cg_drawBannerPrint;
+extern vmCvar_t cg_bannerPrintTime;
 
 // local clock flags
 #define LOCALTIME_ON                0x01
@@ -2757,6 +2763,11 @@ void CG_GetColorForHealth(int health, vec4_t hcolor);
 
 qboolean CG_WorldCoordToScreenCoordFloat(vec3_t point, float *x, float *y);
 void CG_AddOnScreenText(const char *text, vec3_t origin);
+
+// string word wrapper
+char* CG_WordWrapString(const char *input, int maxLineChars, char *output, int maxOutputSize);
+// draws multiline strings
+void CG_DrawMultilineText(float x, float y, float scalex, float scaley, vec4_t color, const char *text, int lineHeight, float adjust, int limit, int style, int align, fontHelper_t *font);
 
 // new hud stuff
 void CG_DrawRect(float x, float y, float width, float height, float size, const float *color);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -351,6 +351,8 @@ vmCvar_t cg_quickchat;
 vmCvar_t cg_drawspeed;
 
 vmCvar_t cg_visualEffects;
+vmCvar_t cg_drawBannerPrint;
+vmCvar_t cg_bannerPrintTime;
 
 
 typedef struct
@@ -598,7 +600,9 @@ static cvarTable_t cvarTable[] =
 
 	{ &cg_drawspeed,              "cg_drawspeed",              "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_visualEffects,          "cg_visualEffects",          "1",           CVAR_ARCHIVE,                 0 }  // Draw visual effects (i.e : airstrike plane, debris ...)
+	{ &cg_visualEffects,          "cg_visualEffects",          "1",           CVAR_ARCHIVE,                 0 },  // Draw visual effects (i.e : airstrike plane, debris ...)
+	{ &cg_drawBannerPrint,        "cg_drawBannerPrint",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_bannerPrintTime,        "cg_bannerPrintTime",        "10000",       CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1970,7 +1970,7 @@ const char *CG_LocalizeServerCommand(const char *buf)
 	static char token[MAX_TOKEN_CHARS];
 	char        temp[MAX_TOKEN_CHARS];
 	qboolean    togloc = qtrue;
-	const char  *s = buf;
+	const char  *s     = buf;
 	int         i, prev = 0;
 
 	Com_Memset(token, 0, sizeof(token));
@@ -2365,7 +2365,7 @@ void CG_parseWeaponStatsGS_cmd(void)
 /**
  * @brief Client-side stat presentation
  */
-void CG_parseWeaponStats_cmd(void(txt_dump) (const char *))
+void CG_parseWeaponStats_cmd(void (txt_dump) (const char *))
 {
 	clientInfo_t *ci;
 	qboolean     fFull;
@@ -2629,7 +2629,7 @@ void CG_parseWeaponStats_cmd(void(txt_dump) (const char *))
  * @brief CG_parseBestShotsStats_cmd
  * @param[in] doTop
  */
-static void CG_parseBestShotsStats_cmd(qboolean doTop, void(txt_dump) (const char *))
+static void CG_parseBestShotsStats_cmd(qboolean doTop, void (txt_dump) (const char *))
 {
 	int      iArg = 1;
 	qboolean fFull;
@@ -2707,7 +2707,7 @@ static void CG_parseBestShotsStats_cmd(qboolean doTop, void(txt_dump) (const cha
  * @brief CG_parseTopShotsStats_cmd
  * @param[in] doTop
  */
-static void CG_parseTopShotsStats_cmd(qboolean doTop, void(txt_dump) (const char *))
+static void CG_parseTopShotsStats_cmd(qboolean doTop, void (txt_dump) (const char *))
 {
 	int i, iArg = 1;
 	int cClients;
@@ -2921,6 +2921,7 @@ void CG_dumpStats(void)
 #define MU_FADE_HASH        87906
 #define SND_FADE_HASH       100375
 #define ROCKANDROLL_HASH    146207
+#define BP_HASH             25102
 // -----------
 
 /**
@@ -3478,6 +3479,10 @@ static void CG_ServerCommand(void)
 	case ROCKANDROLL_HASH: // "rockandroll"
 		trap_S_FadeAllSound(1.0f, 1000, qfalse);      // fade sound up
 		return;
+	case BP_HASH: // "bp"
+		CG_WordWrapString(CG_Argv(1), 50, cg.bannerPrint, sizeof(cg.bannerPrint));
+		cg.bannerPrintTime = cg.time;
+		break;
 	default:
 		CG_Printf("Unknown client game command: %s [%lu]\n", cmd, BG_StringHashValue(cmd));
 		break;

--- a/src/qcommon/q_unicode.c
+++ b/src/qcommon/q_unicode.c
@@ -127,15 +127,17 @@ int Q_UTF8_Strlen(const char *str)
 }
 
 /**
- * @brief Q_UTF8_PrintStrlen
+ * @brief Q_UTF8_PrintStrlen2
  * @param[in] str
+ * @param[in] length string length
  * @return
  */
-int Q_UTF8_PrintStrlen(const char *str)
+int Q_UTF8_PrintStrlenExt(const char *str, int length)
 {
-	int l = 0;
+	int        l      = 0;
+	const char *start = str;
 
-	while (*str)
+	while (*str && (str - start) < length)
 	{
 		if (Q_IsColorString(str))
 		{
@@ -153,6 +155,16 @@ int Q_UTF8_PrintStrlen(const char *str)
 	}
 
 	return l;
+}
+
+/**
+ * @brief Q_UTF8_PrintStrlen
+ * @param[in] str
+ * @return
+ */
+int Q_UTF8_PrintStrlen(const char *str)
+{
+	return Q_UTF8_PrintStrlenExt(str, MAX_QINT);
 }
 
 /**

--- a/src/qcommon/q_unicode.h
+++ b/src/qcommon/q_unicode.h
@@ -56,6 +56,7 @@ int Q_UTF8_Width(const char *str);
 int Q_UTF8_WidthCP(int ch);
 int Q_UTF8_Strlen(const char *str);
 int Q_UTF8_PrintStrlen(const char *str);
+int Q_UTF8_PrintStrlenExt(const char *str, int length);
 int Q_UTF8_ByteOffset(const char *str, int offset);
 void Q_UTF8_Insert(char *dest, int size, int offset, int key, qboolean overstrike);
 void Q_UTF8_Move(char *data, size_t offset1, size_t offset2, size_t size);


### PR DESCRIPTION
This adds message area on the top of the screen.

Can be used to print banners or other messages in a less
distractive way.

This does not implement the banner rotator,
for such feature check out the lua script:
https://github.com/etlegacy/etlegacy-lua_scripts#banners

Client cvars to control it:
cg_drawBannerPrint - toggle the message area
cg_bannerPrintTime - duration the message is displayed